### PR TITLE
Harden production storage and simulator access

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+.env*.local

--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ If you want to run the Telegram-ready version in production today, the app serve
 ### What the server needs today
 
 1. Deploy the Next.js app behind HTTPS.
-2. Run the app with persistent storage for:
-   - `.data/games.json`
-   - `public/uploads/`
+2. Pick one persistence strategy:
+   - zero-config local storage with `.data/games.json` and `public/uploads/`
+   - external storage with Postgres for game state and Blob for uploaded proof media
 3. Expose the public app URL so players can open the web experience and join games.
 
 ### Telegram setup around the app
@@ -65,13 +65,29 @@ npm run dev
 
 Open [http://localhost:3000](http://localhost:3000).
 
+The app defaults to local filesystem storage in development. If you want to force that behavior even when hosted env vars exist on your machine, add this to `.env.local`:
+
+```bash
+PIXELPARTY_GAME_STORAGE=filesystem
+PIXELPARTY_UPLOAD_STORAGE=filesystem
+```
+
 ## Deploying The Next.js App
 
-This project can be deployed like a normal Next.js app, but there is one important caveat: the current MVP writes game state and uploads to the local filesystem.
+This project can be deployed like a normal Next.js app. It supports two persistence shapes:
+
+- local filesystem storage for single-host development or a sandbox/VPS with mounted persistent disk
+- external storage for production-style Next.js hosting, using Postgres for game state and Blob for uploaded evidence
 
 ### Recommended deployment shape
 
-Use a Node.js host where the app can run with persistent disk storage, for example:
+For the most portable production deployment, use:
+
+- a Postgres database for `game.json`-equivalent state
+- Vercel Blob for uploaded photos and videos
+- any Node.js-compatible Next.js host for the app itself
+
+If you prefer to keep everything on one machine, the filesystem fallback still works on:
 
 - a VPS
 - a Docker container with a mounted volume
@@ -89,12 +105,44 @@ By default, `npm run start` serves the production app on port `3000`. Put it beh
 
 ### What must persist in production
 
-The deployment must preserve these paths between restarts and redeploys:
+If you stay on the local filesystem, the deployment must preserve these paths between restarts and redeploys:
 
 - `.data/games.json`
 - `public/uploads/`
 
-If those paths are ephemeral, game progress and uploaded evidence will be lost.
+If you externalize storage, those local paths are no longer required for production durability.
+
+### External storage setup
+
+The app now auto-detects external storage:
+
+- set `POSTGRES_URL` or `DATABASE_URL` to move game persistence out of `.data/games.json`
+- set `BLOB_READ_WRITE_TOKEN` to move uploaded evidence out of `public/uploads/`
+
+Optional overrides:
+
+- `PIXELPARTY_GAME_STORAGE=filesystem|postgres`
+- `PIXELPARTY_UPLOAD_STORAGE=filesystem|blob`
+- `PIXELPARTY_ENABLE_SIMULATOR=true|false`
+
+Example hosted configuration:
+
+```bash
+POSTGRES_URL=postgres://user:password@host:5432/pixelparty
+BLOB_READ_WRITE_TOKEN=vercel_blob_rw_xxxxx
+```
+
+With that setup:
+
+- game reads and writes go to a `games` table in Postgres
+- uploaded photos and videos are stored in Blob under `evidence/...`
+- the app keeps the same API routes and UI behavior
+
+Production note:
+
+- in production, the local simulator is disabled by default
+- if you really want it on a hosted deployment, set `PIXELPARTY_ENABLE_SIMULATOR=true`
+- on serverless-style deployments, leaving game storage on the local filesystem now returns a clear configuration error instead of trying to write into an unavailable `.data` directory
 
 ### Environment and networking checklist
 
@@ -103,16 +151,19 @@ Before going live, make sure the server has:
 - Node.js installed
 - outbound internet access for user-uploaded proof URLs and future integrations
 - an HTTPS public domain
-- enough writable disk space for `.data/` and `public/uploads/`
+- either:
+  - enough writable disk space for `.data/` and `public/uploads/`, or
+  - access to your Postgres database and Blob bucket/token
 
 ### Important hosting note
 
-This app is not yet a good fit for fully ephemeral serverless deployments out of the box. Platforms that rebuild or replace the filesystem on each deploy will need a storage rewrite first, typically:
+The storage rewrite that used to be required for ephemeral Next.js hosting is now built in:
 
-- move game state from `.data/games.json` into a database
-- move uploaded files from `public/uploads/` into object storage
+- game state can live in Postgres
+- uploaded files can live in Blob
+- the filesystem remains available as a local fallback for simulator work and single-host setups
 
-Once those two pieces are externalized, the app will be much easier to run on serverless Next.js platforms.
+Edge Config was intentionally not used for live game state because this app updates game data frequently during play, while Edge Config is better suited to frequently read, infrequently changed configuration data such as flags, redirects, or feature switches.
 
 ## Main Routes
 
@@ -131,4 +182,4 @@ npm run build
 
 ## Persistence
 
-Game state is stored in `.data/games.json` while the app runs locally. Uploaded proof files are stored in `public/uploads/`. Both are ignored by git.
+By default, local development stores game state in `.data/games.json` and uploaded proof files in `public/uploads/`. In hosted environments, you can externalize those two pieces with Postgres and Blob while keeping the same application code paths.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "pixelparty",
       "version": "0.1.0",
       "dependencies": {
+        "@vercel/blob": "^2.3.1",
         "next": "16.2.1",
+        "postgres": "^3.4.8",
         "react": "19.2.4",
         "react-dom": "19.2.4"
       },
@@ -2530,6 +2532,31 @@
         "win32"
       ]
     },
+    "node_modules/@vercel/blob": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.3.1.tgz",
+      "integrity": "sha512-6f9oWC+DbWxIgBLOdqjjn2/REpFrPDB7y5B5HA1ptYkzZaBgL6E34kWrptJvJ7teApJdbAs3I1a5A7z1y8SDHw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "is-buffer": "^2.0.5",
+        "is-node-process": "^1.2.0",
+        "throttleit": "^2.1.0",
+        "undici": "^6.23.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@vercel/blob/node_modules/undici": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
     "node_modules/@vitest/expect": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.1.tgz",
@@ -2912,6 +2939,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -4712,6 +4748,29 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.5.tgz",
+      "integrity": "sha512-i2R6zNFDwgEHJyQUtJEk0XFi1i0dPFn/oqjK3/vPCcDeJvW5NQ83V8QbicfF1SupOaB0h8ntgBC2YiE7dfyctQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/is-bun-module": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-bun-module/-/is-bun-module-2.0.0.tgz",
@@ -4883,6 +4942,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-node-process": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+      "integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+      "license": "MIT"
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -6121,6 +6186,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postgres": {
+      "version": "3.4.8",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.4.8.tgz",
+      "integrity": "sha512-d+JFcLM17njZaOLkv6SCev7uoLaBtfK86vMUXhW1Z4glPWh4jozno9APvW/XKFJ3CCxVoC7OL38BqRydtu5nGg==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -6347,6 +6425,15 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -6963,6 +7050,18 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/throttleit": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-2.1.0.tgz",
+      "integrity": "sha512-nt6AMGKW1p/70DF/hGBdJB57B8Tspmbp5gfJ8ilhLnt7kkr2ye7hzD6NVG8GGErk2HWF34igrL2CXmNIkzKqKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test:watch": "vitest"
   },
   "dependencies": {
+    "@vercel/blob": "^2.3.1",
     "next": "16.2.1",
+    "postgres": "^3.4.8",
     "react": "19.2.4",
     "react-dom": "19.2.4"
   },

--- a/src/app/api/games/[gameId]/days/next/route.ts
+++ b/src/app/api/games/[gameId]/days/next/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { advanceDay } from "@/lib/game-engine";
 import { jsonError } from "@/lib/route-response";
+import { assertSimulatorEnabled } from "@/lib/storage-config";
 import { updateGame } from "@/lib/store";
 
 export async function POST(
@@ -9,8 +10,19 @@ export async function POST(
 ) {
   try {
     const { gameId } = await context.params;
-    const game = await updateGame(gameId, (current) => advanceDay(current));
-    return NextResponse.json({ ok: true, gameId: game.id, currentDay: game.currentDay, status: game.status });
+    const game = await updateGame(gameId, (current) => {
+      if (current.accessMode === "simulator") {
+        assertSimulatorEnabled();
+      }
+
+      return advanceDay(current);
+    });
+    return NextResponse.json({
+      ok: true,
+      gameId: game.id,
+      currentDay: game.currentDay,
+      status: game.status,
+    });
   } catch (error) {
     return jsonError(error);
   }

--- a/src/app/api/games/[gameId]/finish/route.ts
+++ b/src/app/api/games/[gameId]/finish/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { finishGame } from "@/lib/game-engine";
 import { jsonError } from "@/lib/route-response";
+import { assertSimulatorEnabled } from "@/lib/storage-config";
 import { updateGame } from "@/lib/store";
 
 export async function POST(
@@ -9,7 +10,13 @@ export async function POST(
 ) {
   try {
     const { gameId } = await context.params;
-    const game = await updateGame(gameId, (current) => finishGame(current));
+    const game = await updateGame(gameId, (current) => {
+      if (current.accessMode === "simulator") {
+        assertSimulatorEnabled();
+      }
+
+      return finishGame(current);
+    });
     return NextResponse.json({ ok: true, gameId: game.id, status: game.status });
   } catch (error) {
     return jsonError(error);

--- a/src/app/api/games/[gameId]/join/route.ts
+++ b/src/app/api/games/[gameId]/join/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { joinGame } from "@/lib/game-engine";
 import { jsonError } from "@/lib/route-response";
+import { assertSimulatorEnabled } from "@/lib/storage-config";
 import { updateGame } from "@/lib/store";
 import { JoinGameInput } from "@/lib/types";
 
@@ -14,6 +15,10 @@ export async function POST(
     let joinedPlayerId = "";
 
     const game = await updateGame(gameId, (current) => {
+      if (current.accessMode === "simulator") {
+        assertSimulatorEnabled();
+      }
+
       const result = joinGame(current, body);
       joinedPlayerId = result.player.id;
       return result.game;

--- a/src/app/api/games/[gameId]/players/[playerId]/activity/route.ts
+++ b/src/app/api/games/[gameId]/players/[playerId]/activity/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { submitActivity } from "@/lib/game-engine";
 import { jsonError } from "@/lib/route-response";
+import { assertSimulatorEnabled } from "@/lib/storage-config";
 import { updateGame } from "@/lib/store";
 import { SubmitActivityInput } from "@/lib/types";
 
@@ -11,9 +12,13 @@ export async function POST(
   try {
     const { gameId, playerId } = await context.params;
     const body = (await request.json()) as SubmitActivityInput;
-    const game = await updateGame(gameId, (current) =>
-      submitActivity(current, playerId, body),
-    );
+    const game = await updateGame(gameId, (current) => {
+      if (current.accessMode === "simulator") {
+        assertSimulatorEnabled();
+      }
+
+      return submitActivity(current, playerId, body);
+    });
     return NextResponse.json({ ok: true, gameId: game.id, playerId });
   } catch (error) {
     return jsonError(error);

--- a/src/app/api/games/[gameId]/quests/[questId]/evidence/route.ts
+++ b/src/app/api/games/[gameId]/quests/[questId]/evidence/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { submitEvidence } from "@/lib/game-engine";
 import { jsonError } from "@/lib/route-response";
+import { assertSimulatorEnabled } from "@/lib/storage-config";
 import { updateGame } from "@/lib/store";
 import { saveBrowserFile } from "@/lib/uploads";
 
@@ -26,14 +27,18 @@ export async function POST(
       fileName = saved.fileName;
     }
 
-    const game = await updateGame(gameId, (current) =>
-      submitEvidence(current, playerId, questId, {
+    const game = await updateGame(gameId, (current) => {
+      if (current.accessMode === "simulator") {
+        assertSimulatorEnabled();
+      }
+
+      return submitEvidence(current, playerId, questId, {
         description,
         kind: kind === "video" ? "video" : "photo",
         assetUrl,
         fileName,
-      }),
-    );
+      });
+    });
 
     return NextResponse.json({ ok: true, gameId: game.id, questId });
   } catch (error) {

--- a/src/app/api/games/[gameId]/quests/[questId]/validate/route.ts
+++ b/src/app/api/games/[gameId]/quests/[questId]/validate/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { jsonError } from "@/lib/route-response";
+import { assertSimulatorEnabled } from "@/lib/storage-config";
 import { updateGame } from "@/lib/store";
 import { validateQuest } from "@/lib/game-engine";
 import { ValidateQuestInput } from "@/lib/types";
@@ -12,12 +13,16 @@ export async function POST(
     const { gameId, questId } = await context.params;
     const body = (await request.json()) as ValidateQuestInput & { playerId: string };
 
-    const game = await updateGame(gameId, (current) =>
-      validateQuest(current, body.playerId, questId, {
+    const game = await updateGame(gameId, (current) => {
+      if (current.accessMode === "simulator") {
+        assertSimulatorEnabled();
+      }
+
+      return validateQuest(current, body.playerId, questId, {
         decision: body.decision,
         note: body.note,
-      }),
-    );
+      });
+    });
 
     return NextResponse.json({ ok: true, gameId: game.id, questId });
   } catch (error) {

--- a/src/app/api/games/[gameId]/reset/route.ts
+++ b/src/app/api/games/[gameId]/reset/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { assertCanManageGame, resetGame } from "@/lib/game-engine";
 import { jsonError } from "@/lib/route-response";
+import { assertSimulatorEnabled } from "@/lib/storage-config";
 import { updateGame } from "@/lib/store";
 
 export async function POST(
@@ -12,6 +13,10 @@ export async function POST(
     const body = (await request.json().catch(() => ({}))) as { playerId?: string };
 
     const game = await updateGame(gameId, (current) => {
+      if (current.accessMode === "simulator") {
+        assertSimulatorEnabled();
+      }
+
       assertCanManageGame(current, body.playerId);
       return resetGame(current);
     });

--- a/src/app/api/games/[gameId]/route.ts
+++ b/src/app/api/games/[gameId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { assertCanManageGame } from "@/lib/game-engine";
 import { jsonError } from "@/lib/route-response";
+import { assertSimulatorEnabled } from "@/lib/storage-config";
 import { deleteGame, getGame } from "@/lib/store";
 
 export const dynamic = "force-dynamic";
@@ -15,6 +16,10 @@ export async function GET(
 
     if (!game) {
       return NextResponse.json({ error: "Game not found." }, { status: 404 });
+    }
+
+    if (game.accessMode === "simulator") {
+      assertSimulatorEnabled();
     }
 
     return NextResponse.json(game);
@@ -34,6 +39,10 @@ export async function DELETE(
 
     if (!game) {
       return NextResponse.json({ error: "Game not found." }, { status: 404 });
+    }
+
+    if (game.accessMode === "simulator") {
+      assertSimulatorEnabled();
     }
 
     assertCanManageGame(game, body.playerId);

--- a/src/app/api/games/[gameId]/start/route.ts
+++ b/src/app/api/games/[gameId]/start/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import { startGame } from "@/lib/game-engine";
 import { jsonError } from "@/lib/route-response";
+import { assertSimulatorEnabled } from "@/lib/storage-config";
 import { updateGame } from "@/lib/store";
 
 export async function POST(
@@ -9,7 +10,13 @@ export async function POST(
 ) {
   try {
     const { gameId } = await context.params;
-    const game = await updateGame(gameId, (current) => startGame(current));
+    const game = await updateGame(gameId, (current) => {
+      if (current.accessMode === "simulator") {
+        assertSimulatorEnabled();
+      }
+
+      return startGame(current);
+    });
     return NextResponse.json({ ok: true, gameId: game.id, currentDay: game.currentDay });
   } catch (error) {
     return jsonError(error);

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -1,12 +1,18 @@
 import { NextResponse } from "next/server";
 import { createGame } from "@/lib/game-engine";
 import { jsonError } from "@/lib/route-response";
+import { assertSimulatorEnabled } from "@/lib/storage-config";
 import { saveGame } from "@/lib/store";
 import { CreateGameInput } from "@/lib/types";
 
 export async function POST(request: Request) {
   try {
     const body = (await request.json()) as CreateGameInput;
+
+    if (body.accessMode === "simulator") {
+      assertSimulatorEnabled();
+    }
+
     const game = createGame(body);
     await saveGame(game);
 

--- a/src/app/game/[gameId]/page.tsx
+++ b/src/app/game/[gameId]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { GameClient } from "@/components/GameClient";
+import { isSimulatorEnabled } from "@/lib/storage-config";
 import { getGame } from "@/lib/store";
 
 export const dynamic = "force-dynamic";
@@ -16,6 +17,10 @@ export default async function GamePage({
   const game = await getGame(gameId);
 
   if (!game) {
+    notFound();
+  }
+
+  if (game.accessMode === "simulator" && !isSimulatorEnabled()) {
     notFound();
   }
 

--- a/src/app/join/[inviteCode]/page.tsx
+++ b/src/app/join/[inviteCode]/page.tsx
@@ -1,5 +1,6 @@
 import { notFound } from "next/navigation";
 import { JoinClient } from "@/components/JoinClient";
+import { isSimulatorEnabled } from "@/lib/storage-config";
 import { getGameByInvite } from "@/lib/store";
 
 export const dynamic = "force-dynamic";
@@ -13,6 +14,10 @@ export default async function JoinPage({
   const game = await getGameByInvite(inviteCode);
 
   if (!game) {
+    notFound();
+  }
+
+  if (game.accessMode === "simulator" && !isSimulatorEnabled()) {
     notFound();
   }
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import { HomeClient } from "@/components/HomeClient";
+import { isSimulatorEnabled } from "@/lib/storage-config";
 
 export default function Home() {
-  return <HomeClient />;
+  return <HomeClient showSimulatorLink={isSimulatorEnabled()} />;
 }

--- a/src/app/simulator/page.tsx
+++ b/src/app/simulator/page.tsx
@@ -1,9 +1,36 @@
+import Link from "next/link";
 import { SimulatorClient } from "@/components/SimulatorClient";
+import { isSimulatorEnabled } from "@/lib/storage-config";
 import { listGames } from "@/lib/store";
 
 export const dynamic = "force-dynamic";
 
 export default async function SimulatorPage() {
+  if (!isSimulatorEnabled()) {
+    return (
+      <main
+        style={{
+          maxWidth: "720px",
+          margin: "0 auto",
+          padding: "4rem 1.5rem",
+          display: "grid",
+          gap: "1rem",
+        }}
+      >
+        <p style={{ fontWeight: 700, letterSpacing: "0.08em", textTransform: "uppercase" }}>
+          Local Simulator
+        </p>
+        <h1 style={{ margin: 0 }}>Simulator unavailable on this deployment.</h1>
+        <p style={{ margin: 0 }}>
+          The simulator is intended for local rehearsal and is disabled in production.
+        </p>
+        <div>
+          <Link href="/">Return to the main app</Link>
+        </div>
+      </main>
+    );
+  }
+
   const games = await listGames();
   return <SimulatorClient games={games} />;
 }

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -25,7 +25,11 @@ const DEFAULT_GAME_TITLE = "Weekend of Bad Decisions";
 const DEFAULT_GROOM_NAME = "Tincho";
 const DEFAULT_HOST_NAME = "Fede";
 
-export function HomeClient() {
+export function HomeClient({
+  showSimulatorLink,
+}: {
+  showSimulatorLink: boolean;
+}) {
   const router = useRouter();
   const [error, setError] = useState("");
   const [isPending, startTransition] = useTransition();
@@ -80,9 +84,11 @@ export function HomeClient() {
             <a href="#create" className={styles.primaryAction}>
               Create The Game
             </a>
-            <Link href="/simulator" className={styles.secondaryAction}>
-              Open Local Simulator
-            </Link>
+            {showSimulatorLink ? (
+              <Link href="/simulator" className={styles.secondaryAction}>
+                Open Local Simulator
+              </Link>
+            ) : null}
           </div>
           <div className={styles.telegramNote}>
             <strong>Telegram note.</strong> This MVP stores Telegram handles and produces Telegram-ready narrator messages. To deliver real bot DMs in production, each player still needs to start the bot once so their chat ID can be linked to the handle.

--- a/src/lib/storage-config.test.ts
+++ b/src/lib/storage-config.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from "vitest";
+import {
+  assertGameStorageAvailable,
+  assertSimulatorEnabled,
+  assertUploadStorageAvailable,
+  getDatabaseUrl,
+  isSimulatorEnabled,
+  resolveGameStorageDriver,
+  resolveUploadStorageDriver,
+} from "@/lib/storage-config";
+
+describe("storage configuration", () => {
+  it("falls back to the filesystem when no external storage is configured", () => {
+    expect(resolveGameStorageDriver({})).toBe("filesystem");
+    expect(resolveUploadStorageDriver({})).toBe("filesystem");
+  });
+
+  it("auto-enables Postgres when a database URL is present", () => {
+    expect(
+      resolveGameStorageDriver({
+        POSTGRES_URL: "postgres://pixelparty.test/game",
+      }),
+    ).toBe("postgres");
+  });
+
+  it("auto-enables Blob when a blob token is present", () => {
+    expect(
+      resolveUploadStorageDriver({
+        BLOB_READ_WRITE_TOKEN: "vercel_blob_rw_test",
+      }),
+    ).toBe("blob");
+  });
+
+  it("lets local development force filesystem storage even when hosted env vars exist", () => {
+    expect(
+      resolveGameStorageDriver({
+        POSTGRES_URL: "postgres://pixelparty.test/game",
+        PIXELPARTY_GAME_STORAGE: "filesystem",
+      }),
+    ).toBe("filesystem");
+
+    expect(
+      resolveUploadStorageDriver({
+        BLOB_READ_WRITE_TOKEN: "vercel_blob_rw_test",
+        PIXELPARTY_UPLOAD_STORAGE: "filesystem",
+      }),
+    ).toBe("filesystem");
+  });
+
+  it("prefers an explicit database URL over an empty fallback", () => {
+    expect(
+      getDatabaseUrl({
+        DATABASE_URL: "postgres://pixelparty.test/game",
+      }),
+    ).toBe("postgres://pixelparty.test/game");
+  });
+
+  it("disables the simulator by default in production", () => {
+    expect(isSimulatorEnabled({ NODE_ENV: "production" })).toBe(false);
+    expect(isSimulatorEnabled({ NODE_ENV: "development" })).toBe(true);
+  });
+
+  it("lets deployments opt back into the simulator explicitly", () => {
+    expect(
+      isSimulatorEnabled({
+        NODE_ENV: "production",
+        PIXELPARTY_ENABLE_SIMULATOR: "true",
+      }),
+    ).toBe(true);
+  });
+
+  it("throws a clear error when serverless production falls back to local game storage", () => {
+    expect(() =>
+      assertGameStorageAvailable({
+        NODE_ENV: "production",
+        VERCEL: "1",
+      }),
+    ).toThrow("External game storage is not configured");
+  });
+
+  it("throws a clear error when serverless production falls back to local upload storage", () => {
+    expect(() =>
+      assertUploadStorageAvailable({
+        NODE_ENV: "production",
+        VERCEL: "1",
+      }),
+    ).toThrow("External upload storage is not configured");
+  });
+
+  it("throws a clear error when the simulator is disabled", () => {
+    expect(() =>
+      assertSimulatorEnabled({
+        NODE_ENV: "production",
+      }),
+    ).toThrow("The local simulator is disabled");
+  });
+});

--- a/src/lib/storage-config.ts
+++ b/src/lib/storage-config.ts
@@ -1,0 +1,104 @@
+export type GameStorageDriver = "filesystem" | "postgres";
+export type UploadStorageDriver = "filesystem" | "blob";
+
+type Environment = Record<string, string | undefined>;
+
+function normalizeDriver(value?: string) {
+  return value?.trim().toLowerCase();
+}
+
+function parseBoolean(value?: string) {
+  const normalized = value?.trim().toLowerCase();
+
+  if (normalized === "true") {
+    return true;
+  }
+
+  if (normalized === "false") {
+    return false;
+  }
+
+  return null;
+}
+
+export function getDatabaseUrl(env: Environment = process.env) {
+  return env.POSTGRES_URL ?? env.DATABASE_URL ?? null;
+}
+
+export function isServerlessFilesystemDeployment(
+  env: Environment = process.env,
+) {
+  return env.VERCEL === "1" || Boolean(env.LAMBDA_TASK_ROOT);
+}
+
+export function resolveGameStorageDriver(
+  env: Environment = process.env,
+): GameStorageDriver {
+  const forcedDriver = normalizeDriver(env.PIXELPARTY_GAME_STORAGE);
+
+  if (forcedDriver === "filesystem") {
+    return "filesystem";
+  }
+
+  if (forcedDriver === "postgres") {
+    return "postgres";
+  }
+
+  return getDatabaseUrl(env) ? "postgres" : "filesystem";
+}
+
+export function resolveUploadStorageDriver(
+  env: Environment = process.env,
+): UploadStorageDriver {
+  const forcedDriver = normalizeDriver(env.PIXELPARTY_UPLOAD_STORAGE);
+
+  if (forcedDriver === "filesystem") {
+    return "filesystem";
+  }
+
+  if (forcedDriver === "blob") {
+    return "blob";
+  }
+
+  return env.BLOB_READ_WRITE_TOKEN ? "blob" : "filesystem";
+}
+
+export function isSimulatorEnabled(env: Environment = process.env) {
+  const explicitSetting =
+    parseBoolean(env.PIXELPARTY_ENABLE_SIMULATOR) ??
+    parseBoolean(env.NEXT_PUBLIC_ENABLE_SIMULATOR);
+
+  if (explicitSetting !== null) {
+    return explicitSetting;
+  }
+
+  return env.NODE_ENV !== "production";
+}
+
+export function assertSimulatorEnabled(env: Environment = process.env) {
+  if (!isSimulatorEnabled(env)) {
+    throw new Error("The local simulator is disabled in this deployment.");
+  }
+}
+
+export function assertGameStorageAvailable(env: Environment = process.env) {
+  if (
+    resolveGameStorageDriver(env) === "filesystem" &&
+    isServerlessFilesystemDeployment(env)
+  ) {
+    throw new Error(
+      "External game storage is not configured for this deployment. Set POSTGRES_URL or DATABASE_URL, or run on a host with persistent writable disk.",
+    );
+  }
+}
+
+export function assertUploadStorageAvailable(env: Environment = process.env) {
+  if (
+    resolveUploadStorageDriver(env) === "filesystem" &&
+    isServerlessFilesystemDeployment(env)
+  ) {
+    throw new Error(
+      "External upload storage is not configured for this deployment. Set BLOB_READ_WRITE_TOKEN, or run on a host with persistent writable disk.",
+    );
+  }
+}

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,6 +1,12 @@
 import { promises as fs } from "fs";
 import path from "path";
+import postgres, { type Sql } from "postgres";
 import { Game } from "@/lib/types";
+import {
+  assertGameStorageAvailable,
+  getDatabaseUrl,
+  resolveGameStorageDriver,
+} from "@/lib/storage-config";
 
 interface StoreShape {
   games: Record<string, Game>;
@@ -9,8 +15,63 @@ interface StoreShape {
 const DATA_DIR = path.join(process.cwd(), ".data");
 const STORE_FILE = path.join(DATA_DIR, "games.json");
 let storeQueue = Promise.resolve();
+let sqlClient: Sql | null = null;
+let ensureGamesTablePromise: Promise<void> | null = null;
+
+interface GameRow {
+  id: string;
+  invite_code: string;
+  created_at: string;
+  updated_at: string;
+  payload: Game;
+}
+
+function getSqlClient() {
+  if (!sqlClient) {
+    const databaseUrl = getDatabaseUrl();
+
+    if (!databaseUrl) {
+      throw new Error(
+        "Postgres storage was selected, but POSTGRES_URL / DATABASE_URL is not set.",
+      );
+    }
+
+    sqlClient = postgres(databaseUrl, { prepare: false });
+  }
+
+  return sqlClient;
+}
+
+async function ensureGamesTable() {
+  if (!ensureGamesTablePromise) {
+    ensureGamesTablePromise = (async () => {
+      const sql = getSqlClient();
+
+      await sql`
+        create table if not exists games (
+          id text primary key,
+          invite_code text not null,
+          created_at timestamptz not null,
+          updated_at timestamptz not null,
+          payload jsonb not null
+        )
+      `;
+      await sql`
+        create unique index if not exists games_invite_code_key
+        on games (lower(invite_code))
+      `;
+      await sql`
+        create index if not exists games_created_at_idx
+        on games (created_at desc)
+      `;
+    })();
+  }
+
+  return ensureGamesTablePromise;
+}
 
 async function ensureStore() {
+  assertGameStorageAvailable();
   await fs.mkdir(DATA_DIR, { recursive: true });
 
   try {
@@ -24,13 +85,13 @@ async function ensureStore() {
   }
 }
 
-export async function readStore(): Promise<StoreShape> {
+async function readFilesystemStore(): Promise<StoreShape> {
   await ensureStore();
   const raw = await fs.readFile(STORE_FILE, "utf8");
   return JSON.parse(raw) as StoreShape;
 }
 
-export async function writeStore(store: StoreShape) {
+async function writeFilesystemStore(store: StoreShape) {
   await ensureStore();
   const tempFile = `${STORE_FILE}.${crypto.randomUUID()}.tmp`;
   await fs.writeFile(tempFile, JSON.stringify(store, null, 2), "utf8");
@@ -46,30 +107,155 @@ async function runExclusive<T>(operation: () => Promise<T>) {
   return next;
 }
 
+function mapGamesToStore(games: Game[]): StoreShape {
+  return {
+    games: Object.fromEntries(games.map((game) => [game.id, game])),
+  };
+}
+
+async function readPostgresStore(): Promise<StoreShape> {
+  await ensureGamesTable();
+  const sql = getSqlClient();
+  const rows = await sql<GameRow[]>`
+    select id, invite_code, created_at, updated_at, payload
+    from games
+    order by created_at desc
+  `;
+  return mapGamesToStore(rows.map((row) => row.payload));
+}
+
+async function writePostgresStore(store: StoreShape) {
+  await ensureGamesTable();
+  const sql = getSqlClient();
+  const games = Object.values(store.games);
+
+  await sql.begin(async (transaction) => {
+    const tx = transaction as unknown as Sql;
+
+    if (games.length === 0) {
+      await tx`delete from games`;
+      return;
+    }
+
+    await tx`delete from games`;
+
+    for (const game of games) {
+      await tx`
+        insert into games (id, invite_code, created_at, updated_at, payload)
+        values (
+          ${game.id},
+          ${game.inviteCode},
+          ${game.createdAt},
+          ${game.updatedAt},
+          cast(${JSON.stringify(game)} as jsonb)
+        )
+        on conflict (id) do update set
+          invite_code = excluded.invite_code,
+          created_at = excluded.created_at,
+          updated_at = excluded.updated_at,
+          payload = excluded.payload
+      `;
+    }
+  });
+}
+
+export async function readStore(): Promise<StoreShape> {
+  if (resolveGameStorageDriver() === "postgres") {
+    return readPostgresStore();
+  }
+
+  return readFilesystemStore();
+}
+
+export async function writeStore(store: StoreShape) {
+  if (resolveGameStorageDriver() === "postgres") {
+    await writePostgresStore(store);
+    return;
+  }
+
+  await writeFilesystemStore(store);
+}
+
 export async function listGames() {
-  const store = await readStore();
+  if (resolveGameStorageDriver() === "postgres") {
+    await ensureGamesTable();
+    const sql = getSqlClient();
+    const rows = await sql<GameRow[]>`
+      select id, invite_code, created_at, updated_at, payload
+      from games
+      order by created_at desc
+    `;
+    return rows.map((row) => row.payload);
+  }
+
+  const store = await readFilesystemStore();
   return Object.values(store.games).sort((left, right) =>
     right.createdAt.localeCompare(left.createdAt),
   );
 }
 
 export async function getGame(gameId: string) {
-  const store = await readStore();
+  if (resolveGameStorageDriver() === "postgres") {
+    await ensureGamesTable();
+    const sql = getSqlClient();
+    const rows = await sql<GameRow[]>`
+      select id, invite_code, created_at, updated_at, payload
+      from games
+      where id = ${gameId}
+      limit 1
+    `;
+    return rows[0]?.payload;
+  }
+
+  const store = await readFilesystemStore();
   return store.games[gameId];
 }
 
 export async function getGameByInvite(inviteCode: string) {
-  const store = await readStore();
+  if (resolveGameStorageDriver() === "postgres") {
+    await ensureGamesTable();
+    const sql = getSqlClient();
+    const rows = await sql<GameRow[]>`
+      select id, invite_code, created_at, updated_at, payload
+      from games
+      where lower(invite_code) = lower(${inviteCode})
+      limit 1
+    `;
+    return rows[0]?.payload;
+  }
+
+  const store = await readFilesystemStore();
   return Object.values(store.games).find(
     (game) => game.inviteCode.toLowerCase() === inviteCode.toLowerCase(),
   );
 }
 
 export async function saveGame(game: Game) {
+  if (resolveGameStorageDriver() === "postgres") {
+    await ensureGamesTable();
+    const sql = getSqlClient();
+    await sql`
+      insert into games (id, invite_code, created_at, updated_at, payload)
+      values (
+        ${game.id},
+        ${game.inviteCode},
+        ${game.createdAt},
+        ${game.updatedAt},
+        cast(${JSON.stringify(game)} as jsonb)
+      )
+      on conflict (id) do update set
+        invite_code = excluded.invite_code,
+        created_at = excluded.created_at,
+        updated_at = excluded.updated_at,
+        payload = excluded.payload
+    `;
+    return game;
+  }
+
   return runExclusive(async () => {
-    const store = await readStore();
+    const store = await readFilesystemStore();
     store.games[game.id] = game;
-    await writeStore(store);
+    await writeFilesystemStore(store);
     return game;
   });
 }
@@ -78,8 +264,41 @@ export async function updateGame(
   gameId: string,
   updater: (game: Game) => Game,
 ) {
+  if (resolveGameStorageDriver() === "postgres") {
+    await ensureGamesTable();
+    const sql = getSqlClient();
+
+    return sql.begin(async (transaction) => {
+      const tx = transaction as unknown as Sql;
+      const rows = await tx<GameRow[]>`
+        select id, invite_code, created_at, updated_at, payload
+        from games
+        where id = ${gameId}
+        for update
+      `;
+      const game = rows[0]?.payload;
+
+      if (!game) {
+        throw new Error("Game not found.");
+      }
+
+      const updatedGame = updater(structuredClone(game));
+
+      await tx`
+        update games
+        set invite_code = ${updatedGame.inviteCode},
+            created_at = ${updatedGame.createdAt},
+            updated_at = ${updatedGame.updatedAt},
+            payload = cast(${JSON.stringify(updatedGame)} as jsonb)
+        where id = ${gameId}
+      `;
+
+      return updatedGame;
+    });
+  }
+
   return runExclusive(async () => {
-    const store = await readStore();
+    const store = await readFilesystemStore();
     const game = store.games[gameId];
 
     if (!game) {
@@ -87,20 +306,36 @@ export async function updateGame(
     }
 
     store.games[gameId] = updater(structuredClone(game));
-    await writeStore(store);
+    await writeFilesystemStore(store);
     return store.games[gameId];
   });
 }
 
 export async function deleteGame(gameId: string) {
+  if (resolveGameStorageDriver() === "postgres") {
+    await ensureGamesTable();
+    const sql = getSqlClient();
+    const rows = await sql<{ id: string }[]>`
+      delete from games
+      where id = ${gameId}
+      returning id
+    `;
+
+    if (rows.length === 0) {
+      throw new Error("Game not found.");
+    }
+
+    return;
+  }
+
   return runExclusive(async () => {
-    const store = await readStore();
+    const store = await readFilesystemStore();
 
     if (!store.games[gameId]) {
       throw new Error("Game not found.");
     }
 
     delete store.games[gameId];
-    await writeStore(store);
+    await writeFilesystemStore(store);
   });
 }

--- a/src/lib/uploads.ts
+++ b/src/lib/uploads.ts
@@ -1,9 +1,15 @@
 import { promises as fs } from "fs";
 import path from "path";
+import { put } from "@vercel/blob";
+import {
+  assertUploadStorageAvailable,
+  resolveUploadStorageDriver,
+} from "@/lib/storage-config";
 
 const UPLOAD_DIR = path.join(process.cwd(), "public", "uploads");
 
-export async function saveBrowserFile(file: File) {
+async function saveLocalBrowserFile(file: File) {
+  assertUploadStorageAvailable();
   const bytes = Buffer.from(await file.arrayBuffer());
   const extension = path.extname(file.name) || ".bin";
   const fileName = `${crypto.randomUUID().slice(0, 8)}${extension}`;
@@ -16,4 +22,27 @@ export async function saveBrowserFile(file: File) {
     assetUrl: `/uploads/${fileName}`,
     fileName: file.name,
   };
+}
+
+async function saveBlobBrowserFile(file: File) {
+  const extension = path.extname(file.name) || ".bin";
+  const blobPath = `evidence/${crypto.randomUUID()}${extension}`;
+  const uploaded = await put(blobPath, file, {
+    access: "public",
+    addRandomSuffix: false,
+    contentType: file.type || undefined,
+  });
+
+  return {
+    assetUrl: uploaded.url,
+    fileName: file.name,
+  };
+}
+
+export async function saveBrowserFile(file: File) {
+  if (resolveUploadStorageDriver() === "blob") {
+    return saveBlobBrowserFile(file);
+  }
+
+  return saveLocalBrowserFile(file);
 }


### PR DESCRIPTION
## Summary
- hide and guard the local simulator by default in production deployments
- return clear configuration errors when serverless deployments are missing external game or upload storage
- add Postgres and Blob-backed storage selection plus tests and deployment docs

## Verification
- npm test
- npm run lint
- npx tsc --noEmit