### PR TITLE
[codex] Add game flow tests and Telegram setup docs

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -e
+
+npm run test:precommit

--- a/README.md
+++ b/README.md
@@ -16,45 +16,87 @@ Pixel-art multiplayer bachelor-party WebApp inspired by the original `tincho-en-
 - A final scoreboard with player titles and an epic wrap-up
 - A `/simulator` route where players can join using names only and test the full lifecycle locally
 
-## Important Telegram Constraint
+## Telegram Setup
 
-This project stores Telegram handles and creates Telegram-ready messages in the game feed, but it does not yet push real Telegram bot DMs. Telegram bots cannot reliably message users from just a username; each player must start the bot once so the app can bind the handle to a chat ID.
+### Important constraint
 
-## Telegram Server Setup
+This project is Telegram-ready, not Telegram-delivered.
 
-If you want to run the Telegram-ready version in production today, the app server setup is simple because the current codebase does not yet talk directly to the Telegram Bot API.
+Today the app:
 
-### What the server needs today
+- stores Telegram handles for the main web flow
+- renders narrator messages in a Telegram-ready format inside the app
+- does not yet call the Telegram Bot API directly
 
-1. Deploy the Next.js app behind HTTPS.
-2. Pick one persistence strategy:
-   - zero-config local storage with `.data/games.json` and `public/uploads/`
-   - external storage with Postgres for game state and Blob for uploaded proof media
-3. Expose the public app URL so players can open the web experience and join games.
+That means the current app does not require a bot token, webhook, or polling worker to run. Players still need to use their real Telegram handles consistently, and if you want a Telegram bot to open the Web App you configure that around the app, not inside the current codebase.
 
-### Telegram setup around the app
+### Local Telegram-ready setup
+
+Use this when you want to test the real web flow on your machine instead of the `/simulator` route.
+
+1. Start the app locally:
+
+```bash
+npm install
+npm run dev
+```
+
+2. Open [http://localhost:3000](http://localhost:3000).
+3. Create a game from `/` using the normal Telegram-ready form.
+4. Enter real-looking Telegram handles such as `@fede`, `@mauri`, and `@seba` when creating and joining players.
+5. Share the local invite link manually with anyone else testing on the same network, or just open the join page yourself in another browser session.
+
+Optional local bot setup:
 
 1. Create a bot with BotFather.
-2. Ask every player to start the bot once in Telegram.
-3. If you want the bot to open this web app, configure the bot menu or button to point to your deployed HTTPS URL.
-4. Have players enter the same Telegram handle they use in Telegram when joining the non-simulator flow.
+2. Ask testers to start the bot once in Telegram.
+3. If you want Telegram to open the local Web App, expose your local app through an HTTPS tunnel such as `ngrok`, `Cloudflare Tunnel`, or similar.
+4. Point the bot menu button or Web App button at that public HTTPS tunnel URL.
 
-### What is not wired yet
+Local environment notes:
 
-- The app does not currently read a Telegram bot token from the server.
-- The app does not currently register a Telegram webhook or run polling.
-- The app does not currently store Telegram chat IDs.
-- The app does not currently send real Telegram DMs; it only creates Telegram-ready narrator messages inside the app feed.
+- no Telegram-specific environment variable is required today
+- `.env.local` is only needed if you want to force a specific storage mode locally
+- the simulator can stay enabled locally with the default development behavior, or explicitly with `PIXELPARTY_ENABLE_SIMULATOR=true`
 
-### What you will need when bot delivery is implemented
+Example local `.env.local`:
 
-When the Telegram integration is added, the production server will need:
+```bash
+PIXELPARTY_GAME_STORAGE=filesystem
+PIXELPARTY_UPLOAD_STORAGE=filesystem
+PIXELPARTY_ENABLE_SIMULATOR=true
+```
 
-- a Telegram bot token in environment variables
-- a webhook endpoint or polling worker
-- persistent mapping between Telegram users and chat IDs
-- bot commands or deep links so players can bind their Telegram account to the game
-- HTTPS on the public domain used by the webhook and the Web App
+### Production Telegram-ready setup
+
+Use this when you want the normal web flow deployed for real players.
+
+1. Deploy the Next.js app behind HTTPS.
+2. Configure persistent storage:
+   - `POSTGRES_URL` or `DATABASE_URL` for game state
+   - `BLOB_READ_WRITE_TOKEN` for uploaded evidence
+3. Keep the simulator disabled unless you explicitly want it:
+   - `PIXELPARTY_ENABLE_SIMULATOR=false`
+4. Create a bot with BotFather if you want Telegram to be the entrypoint into the web app.
+5. Ask every player to start the bot once in Telegram.
+6. Point the bot menu button, deep link, or Web App button at your deployed HTTPS app URL.
+7. Require players to enter the same Telegram handle they use in Telegram when they join the non-simulator flow.
+
+Example hosted configuration:
+
+```bash
+POSTGRES_URL=postgres://user:password@host:5432/pixelparty
+BLOB_READ_WRITE_TOKEN=vercel_blob_rw_xxxxx
+PIXELPARTY_ENABLE_SIMULATOR=false
+```
+
+Production behavior today:
+
+- the app itself still does not read a Telegram bot token
+- the app still does not register a Telegram webhook or run polling
+- the app still does not store Telegram chat IDs
+- the app still does not send real Telegram DMs
+- Telegram is currently used as identity context and optional app entrypoint, not as a live delivery channel
 
 ## Run Locally
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "start": "next start",
     "lint": "eslint",
     "test": "vitest run",
+    "test:functional": "vitest run src/components/*.test.tsx src/lib/*.test.ts",
+    "test:e2e": "vitest run src/test/e2e/*.test.ts",
+    "test:precommit": "npm run test:functional && npm run test:e2e",
     "test:watch": "vitest"
   },
   "dependencies": {

--- a/src/components/GameClient.controls.test.tsx
+++ b/src/components/GameClient.controls.test.tsx
@@ -1,0 +1,102 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { GameClient } from "@/components/GameClient";
+import { createGame, joinGame, startGame } from "@/lib/game-engine";
+import { mockRouter } from "@/test/setup";
+
+function buildLobbyGame() {
+  const game = createGame({
+    title: "Host Controls",
+    groomName: "Tincho",
+    hostName: "Fede",
+    telegramHandle: "@fede",
+    startDate: "2026-03-27",
+    endDate: "2026-03-30",
+    accessMode: "telegram",
+  });
+
+  joinGame(game, { name: "Mauri", telegramHandle: "@mauri" });
+  joinGame(game, { name: "Seba", telegramHandle: "@seba" });
+
+  return game;
+}
+
+describe("GameClient host controls", () => {
+  it("starts a lobby game from the host controls", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true })));
+    const game = buildLobbyGame();
+    const host = game.players.find((player) => player.id === game.hostPlayerId)!;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<GameClient game={game} currentPlayer={host} />);
+
+    await user.click(screen.getByRole("button", { name: /start game and trigger day 1/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/games/${game.id}/start`,
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+
+    expect(mockRouter.refresh).toHaveBeenCalled();
+  });
+
+  it("advances the day and can end the game early for the host", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true })))
+      .mockResolvedValueOnce(new Response(JSON.stringify({ ok: true })));
+    const game = buildLobbyGame();
+    const host = game.players.find((player) => player.id === game.hostPlayerId)!;
+
+    startGame(game);
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<GameClient game={game} currentPlayer={host} />);
+
+    await user.click(screen.getByRole("button", { name: /advance to next day/i }));
+    await user.click(screen.getByRole("button", { name: /end game now/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        1,
+        `/api/games/${game.id}/days/next`,
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+      expect(fetchMock).toHaveBeenNthCalledWith(
+        2,
+        `/api/games/${game.id}/finish`,
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+  });
+
+  it("copies the public invite link", async () => {
+    const user = userEvent.setup();
+    const game = buildLobbyGame();
+    const host = game.players.find((player) => player.id === game.hostPlayerId)!;
+    const writeTextMock = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue();
+
+    render(<GameClient game={game} currentPlayer={host} />);
+
+    await user.click(screen.getByRole("button", { name: /copy invite link/i }));
+
+    expect(writeTextMock).toHaveBeenCalledWith(
+      `${window.location.origin}/join/${game.inviteCode}`,
+    );
+    expect(screen.getByText(/invite copied/i)).toBeInTheDocument();
+  });
+});

--- a/src/components/HomeClient.test.tsx
+++ b/src/components/HomeClient.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { HomeClient } from "@/components/HomeClient";
+import { mockRouter } from "@/test/setup";
+
+describe("HomeClient", () => {
+  it("creates a telegram game and routes to the host dashboard", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          gameId: "game_123",
+          hostPlayerId: "player_123",
+        }),
+      ),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<HomeClient showSimulatorLink />);
+
+    await user.type(screen.getByLabelText(/host telegram/i), "@fede");
+    await user.click(
+      screen.getByRole("button", { name: /create telegram-ready game/i }),
+    );
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        "/api/games",
+        expect.objectContaining({
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+        }),
+      );
+    });
+
+    const [, request] = fetchMock.mock.calls[0] ?? [];
+    const payload = JSON.parse(String(request?.body ?? "{}")) as Record<string, string>;
+
+    expect(payload.accessMode).toBe("telegram");
+    expect(payload.telegramHandle).toBe("@fede");
+
+    await waitFor(() => {
+      expect(mockRouter.push).toHaveBeenCalledWith("/game/game_123?player=player_123");
+    });
+  });
+});

--- a/src/components/JoinClient.test.tsx
+++ b/src/components/JoinClient.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+import { JoinClient } from "@/components/JoinClient";
+import { createGame } from "@/lib/game-engine";
+import { mockRouter } from "@/test/setup";
+
+describe("JoinClient", () => {
+  it("joins a lobby game and routes the player into the game", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ playerId: "player_joined" })),
+    );
+    const game = createGame({
+      title: "Weekend of Bad Decisions",
+      groomName: "Tincho",
+      hostName: "Fede",
+      telegramHandle: "@fede",
+      startDate: "2026-03-27",
+      endDate: "2026-03-30",
+      accessMode: "telegram",
+    });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<JoinClient game={game} />);
+
+    await user.type(screen.getByLabelText(/your name/i), "Luqui");
+    await user.type(screen.getByLabelText(/telegram handle/i), "@luqui");
+    await user.click(screen.getByRole("button", { name: /join the party/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/games/${game.id}/join`,
+        expect.objectContaining({
+          method: "POST",
+        }),
+      );
+    });
+
+    const [, request] = fetchMock.mock.calls[0] ?? [];
+    const payload = JSON.parse(String(request?.body ?? "{}")) as Record<string, string>;
+
+    expect(payload.name).toBe("Luqui");
+    expect(payload.telegramHandle).toBe("@luqui");
+
+    await waitFor(() => {
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        `/game/${game.id}?player=player_joined`,
+      );
+    });
+  });
+});

--- a/src/test/e2e/local-game-flows.test.ts
+++ b/src/test/e2e/local-game-flows.test.ts
@@ -1,0 +1,272 @@
+import { mkdtemp, rm } from "fs/promises";
+import os from "os";
+import path from "path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  formRequest,
+  jsonRequest,
+  readJson,
+  routeContext,
+} from "@/test/route-helpers";
+
+describe.sequential("local filesystem game flows", () => {
+  const originalEnv = { ...process.env };
+  const originalCwd = process.cwd();
+  let tempDir = "";
+
+  beforeEach(async () => {
+    tempDir = await mkdtemp(path.join(os.tmpdir(), "pixelparty-local-"));
+    process.chdir(tempDir);
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: "test",
+      PIXELPARTY_ENABLE_SIMULATOR: "true",
+    };
+    delete process.env.POSTGRES_URL;
+    delete process.env.DATABASE_URL;
+    delete process.env.BLOB_READ_WRITE_TOKEN;
+    delete process.env.VERCEL;
+    vi.resetModules();
+  });
+
+  afterEach(async () => {
+    process.chdir(originalCwd);
+    process.env = { ...originalEnv };
+    vi.resetModules();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("runs the common telegram game lifecycle against local storage", async () => {
+    const gamesRoute = await import("@/app/api/games/route");
+    const gameRoute = await import("@/app/api/games/[gameId]/route");
+    const joinRoute = await import("@/app/api/games/[gameId]/join/route");
+    const startRoute = await import("@/app/api/games/[gameId]/start/route");
+    const nextDayRoute = await import("@/app/api/games/[gameId]/days/next/route");
+    const finishRoute = await import("@/app/api/games/[gameId]/finish/route");
+    const store = await import("@/lib/store");
+
+    const createResponse = await gamesRoute.POST(
+      jsonRequest("http://localhost/api/games", {
+        title: "Weekend of Bad Decisions",
+        groomName: "Tincho",
+        hostName: "Fede",
+        telegramHandle: "@fede",
+        startDate: "2026-03-27",
+        endDate: "2026-03-30",
+        accessMode: "telegram",
+      }),
+    );
+    const created = await readJson<{
+      gameId: string;
+      inviteCode: string;
+      hostPlayerId: string;
+    }>(createResponse);
+
+    expect(createResponse.ok).toBe(true);
+    expect(created.inviteCode).toHaveLength(6);
+
+    const storedGame = await store.getGame(created.gameId);
+    const inviteGame = await store.getGameByInvite(created.inviteCode);
+
+    expect(storedGame?.hostPlayerId).toBe(created.hostPlayerId);
+    expect(inviteGame?.id).toBe(created.gameId);
+
+    for (const player of [
+      { name: "Mauri", telegramHandle: "@mauri" },
+      { name: "Seba", telegramHandle: "@seba" },
+    ]) {
+      const joinResponse = await joinRoute.POST(
+        jsonRequest(`http://localhost/api/games/${created.gameId}/join`, player),
+        routeContext({ gameId: created.gameId }),
+      );
+      expect(joinResponse.ok).toBe(true);
+    }
+
+    const startResponse = await startRoute.POST(
+      new Request(`http://localhost/api/games/${created.gameId}/start`, {
+        method: "POST",
+      }),
+      routeContext({ gameId: created.gameId }),
+    );
+    const started = await readJson<{ currentDay: number }>(startResponse);
+
+    expect(startResponse.ok).toBe(true);
+    expect(started.currentDay).toBe(1);
+
+    const nextResponse = await nextDayRoute.POST(
+      new Request(`http://localhost/api/games/${created.gameId}/days/next`, {
+        method: "POST",
+      }),
+      routeContext({ gameId: created.gameId }),
+    );
+    const nextDay = await readJson<{ currentDay: number; status: string }>(nextResponse);
+
+    expect(nextResponse.ok).toBe(true);
+    expect(nextDay.currentDay).toBe(2);
+    expect(nextDay.status).toBe("active");
+
+    const finishResponse = await finishRoute.POST(
+      new Request(`http://localhost/api/games/${created.gameId}/finish`, {
+        method: "POST",
+      }),
+      routeContext({ gameId: created.gameId }),
+    );
+    const finished = await readJson<{ status: string }>(finishResponse);
+
+    expect(finishResponse.ok).toBe(true);
+    expect(finished.status).toBe("finished");
+
+    const getResponse = await gameRoute.GET(
+      new Request(`http://localhost/api/games/${created.gameId}`),
+      routeContext({ gameId: created.gameId }),
+    );
+    const loadedGame = await readJson<{
+      status: string;
+      currentDay: number;
+      players: Array<{ id: string }>;
+      finaleCards: unknown[];
+    }>(getResponse);
+
+    expect(getResponse.ok).toBe(true);
+    expect(loadedGame.status).toBe("finished");
+    expect(loadedGame.currentDay).toBe(2);
+    expect(loadedGame.players).toHaveLength(3);
+    expect(loadedGame.finaleCards.length).toBeGreaterThan(0);
+  });
+
+  it("runs the simulator actions locally, including activity, evidence, validation, reset, and delete", async () => {
+    const gamesRoute = await import("@/app/api/games/route");
+    const gameRoute = await import("@/app/api/games/[gameId]/route");
+    const joinRoute = await import("@/app/api/games/[gameId]/join/route");
+    const startRoute = await import("@/app/api/games/[gameId]/start/route");
+    const nextDayRoute = await import("@/app/api/games/[gameId]/days/next/route");
+    const resetRoute = await import("@/app/api/games/[gameId]/reset/route");
+    const activityRoute = await import(
+      "@/app/api/games/[gameId]/players/[playerId]/activity/route"
+    );
+    const evidenceRoute = await import(
+      "@/app/api/games/[gameId]/quests/[questId]/evidence/route"
+    );
+    const validateRoute = await import(
+      "@/app/api/games/[gameId]/quests/[questId]/validate/route"
+    );
+    const store = await import("@/lib/store");
+
+    const createResponse = await gamesRoute.POST(
+      jsonRequest("http://localhost/api/games", {
+        title: "Simulator Bash",
+        groomName: "Tincho",
+        hostName: "Fede",
+        startDate: "2026-03-27",
+        endDate: "2026-03-29",
+        accessMode: "simulator",
+      }),
+    );
+    const created = await readJson<{
+      gameId: string;
+      hostPlayerId: string;
+    }>(createResponse);
+
+    expect(createResponse.ok).toBe(true);
+
+    for (const name of ["Mauri", "Seba"]) {
+      const joinResponse = await joinRoute.POST(
+        jsonRequest(`http://localhost/api/games/${created.gameId}/join`, { name }),
+        routeContext({ gameId: created.gameId }),
+      );
+      expect(joinResponse.ok).toBe(true);
+    }
+
+    const startResponse = await startRoute.POST(
+      new Request(`http://localhost/api/games/${created.gameId}/start`, {
+        method: "POST",
+      }),
+      routeContext({ gameId: created.gameId }),
+    );
+
+    expect(startResponse.ok).toBe(true);
+
+    const startedGame = await store.getGame(created.gameId);
+    const mauri = startedGame?.players.find((player) => player.name === "Mauri");
+    const seba = startedGame?.players.find((player) => player.name === "Seba");
+    const mauriQuest = startedGame?.quests.find(
+      (quest) =>
+        quest.playerId === mauri?.id && quest.dayNumber === startedGame.currentDay,
+    );
+
+    expect(mauri?.id).toBeTruthy();
+    expect(seba?.id).toBeTruthy();
+    expect(mauriQuest?.id).toBeTruthy();
+
+    const activityResponse = await activityRoute.POST(
+      jsonRequest(
+        `http://localhost/api/games/${created.gameId}/players/${mauri!.id}/activity`,
+        { summary: "I found street food and filmed the chaos." },
+      ),
+      routeContext({ gameId: created.gameId, playerId: mauri!.id }),
+    );
+    expect(activityResponse.ok).toBe(true);
+
+    const evidenceData = new FormData();
+    evidenceData.set("playerId", mauri!.id);
+    evidenceData.set("description", "Proof of the side quest");
+    evidenceData.set("kind", "photo");
+    evidenceData.set("proofUrl", "https://example.com/proof.jpg");
+
+    const evidenceResponse = await evidenceRoute.POST(
+      formRequest(
+        `http://localhost/api/games/${created.gameId}/quests/${mauriQuest!.id}/evidence`,
+        evidenceData,
+      ),
+      routeContext({ gameId: created.gameId, questId: mauriQuest!.id }),
+    );
+    expect(evidenceResponse.ok).toBe(true);
+
+    const validateResponse = await validateRoute.POST(
+      jsonRequest(
+        `http://localhost/api/games/${created.gameId}/quests/${mauriQuest!.id}/validate`,
+        {
+          playerId: seba!.id,
+          decision: "approved",
+          note: "Looks good",
+        },
+      ),
+      routeContext({ gameId: created.gameId, questId: mauriQuest!.id }),
+    );
+    expect(validateResponse.ok).toBe(true);
+
+    const afterValidation = await store.getGame(created.gameId);
+    const validatedQuest = afterValidation?.quests.find(
+      (quest) => quest.id === mauriQuest!.id,
+    );
+
+    expect(validatedQuest?.status).toBe("completed");
+
+    const nextResponse = await nextDayRoute.POST(
+      new Request(`http://localhost/api/games/${created.gameId}/days/next`, {
+        method: "POST",
+      }),
+      routeContext({ gameId: created.gameId }),
+    );
+    const nextDay = await readJson<{ currentDay: number }>(nextResponse);
+
+    expect(nextDay.currentDay).toBe(2);
+
+    const resetResponse = await resetRoute.POST(
+      jsonRequest(`http://localhost/api/games/${created.gameId}/reset`, {}),
+      routeContext({ gameId: created.gameId }),
+    );
+    const reset = await readJson<{ status: string }>(resetResponse);
+
+    expect(resetResponse.ok).toBe(true);
+    expect(reset.status).toBe("lobby");
+
+    const deleteResponse = await gameRoute.DELETE(
+      jsonRequest(`http://localhost/api/games/${created.gameId}`, {}, { method: "DELETE" }),
+      routeContext({ gameId: created.gameId }),
+    );
+
+    expect(deleteResponse.ok).toBe(true);
+    expect(await store.getGame(created.gameId)).toBeUndefined();
+  });
+});

--- a/src/test/e2e/prod-mocked-infrastructure.test.ts
+++ b/src/test/e2e/prod-mocked-infrastructure.test.ts
@@ -1,0 +1,219 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createGame, finishGame, joinGame, startGame, submitEvidence, validateQuest } from "@/lib/game-engine";
+
+interface MockGameRow {
+  id: string;
+  invite_code: string;
+  created_at: string;
+  updated_at: string;
+  payload: unknown;
+}
+
+const mockRows = new Map<string, MockGameRow>();
+const blobPutMock = vi.fn();
+
+function cloneRow(row: MockGameRow) {
+  return {
+    ...row,
+    payload:
+      typeof row.payload === "string"
+        ? row.payload
+        : JSON.parse(JSON.stringify(row.payload)),
+  };
+}
+
+function normalizeQuery(strings: readonly string[]) {
+  return strings.join(" ").replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+vi.mock("postgres", () => ({
+  default: vi.fn(() => {
+    const sql = Object.assign(
+      async (strings: TemplateStringsArray, ...values: unknown[]) => {
+        const query = normalizeQuery(strings);
+
+        if (
+          query.startsWith("create table") ||
+          query.startsWith("create unique index") ||
+          query.startsWith("create index")
+        ) {
+          return [];
+        }
+
+        if (query === "delete from games") {
+          mockRows.clear();
+          return [];
+        }
+
+        if (
+          query.includes("from games order by created_at desc") &&
+          !query.includes("where")
+        ) {
+          return [...mockRows.values()]
+            .sort((left, right) => right.created_at.localeCompare(left.created_at))
+            .map((row) => cloneRow(row));
+        }
+
+        if (query.includes("where id =") && query.includes("limit 1")) {
+          const id = String(values[0]);
+          return mockRows.has(id) ? [cloneRow(mockRows.get(id)!)] : [];
+        }
+
+        if (query.includes("where id =") && query.includes("for update")) {
+          const id = String(values[0]);
+          return mockRows.has(id) ? [cloneRow(mockRows.get(id)!)] : [];
+        }
+
+        if (query.includes("where lower(invite_code) = lower(")) {
+          const inviteCode = String(values[0]).toLowerCase();
+          const row = [...mockRows.values()].find(
+            (entry) => entry.invite_code.toLowerCase() === inviteCode,
+          );
+          return row ? [cloneRow(row)] : [];
+        }
+
+        if (query.startsWith("insert into games")) {
+          const [id, inviteCode, createdAt, updatedAt, payload] = values;
+
+          mockRows.set(String(id), {
+            id: String(id),
+            invite_code: String(inviteCode),
+            created_at: String(createdAt),
+            updated_at: String(updatedAt),
+            payload: typeof payload === "string" ? payload : JSON.stringify(payload),
+          });
+
+          return [];
+        }
+
+        if (query.startsWith("update games")) {
+          const [inviteCode, createdAt, updatedAt, payload, id] = values;
+
+          mockRows.set(String(id), {
+            id: String(id),
+            invite_code: String(inviteCode),
+            created_at: String(createdAt),
+            updated_at: String(updatedAt),
+            payload: typeof payload === "string" ? payload : JSON.stringify(payload),
+          });
+
+          return [];
+        }
+
+        if (query.startsWith("delete from games") && query.includes("returning id")) {
+          const id = String(values[0]);
+          const existed = mockRows.delete(id);
+          return existed ? [{ id }] : [];
+        }
+
+        throw new Error(`Unhandled mocked SQL query: ${query}`);
+      },
+      {
+        begin: async <T>(callback: (sql: unknown) => Promise<T>) => callback(sql),
+      },
+    );
+
+    return sql;
+  }),
+}));
+
+vi.mock("@vercel/blob", () => ({
+  put: blobPutMock,
+}));
+
+describe.sequential("mocked production infrastructure flows", () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    mockRows.clear();
+    blobPutMock.mockReset();
+    blobPutMock.mockResolvedValue({
+      url: "https://blob.vercel-storage.com/evidence/proof.png",
+    });
+    process.env = {
+      ...originalEnv,
+      NODE_ENV: "production",
+      VERCEL: "1",
+      POSTGRES_URL: "postgres://pixelparty.test/game",
+      BLOB_READ_WRITE_TOKEN: "vercel_blob_rw_test",
+      PIXELPARTY_ENABLE_SIMULATOR: "false",
+    };
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.resetModules();
+  });
+
+  it("runs the production storage and upload flow with mocked Postgres and Blob services", async () => {
+    const store = await import("@/lib/store");
+    const uploads = await import("@/lib/uploads");
+
+    const game = createGame({
+      title: "Production Bash",
+      groomName: "Tincho",
+      hostName: "Fede",
+      telegramHandle: "@fede",
+      startDate: "2026-03-27",
+      endDate: "2026-03-29",
+      accessMode: "telegram",
+    });
+
+    await store.saveGame(game);
+
+    const created = await store.getGame(game.id);
+    expect(created?.players).toHaveLength(1);
+
+    await store.updateGame(game.id, (current) => {
+      joinGame(current, { name: "Mauri", telegramHandle: "@mauri" });
+      joinGame(current, { name: "Seba", telegramHandle: "@seba" });
+      return startGame(current);
+    });
+
+    const startedGame = await store.getGame(game.id);
+    const mauri = startedGame?.players.find((player) => player.name === "Mauri");
+    const seba = startedGame?.players.find((player) => player.name === "Seba");
+    const mauriQuest = startedGame?.quests.find(
+      (quest) =>
+        quest.playerId === mauri?.id && quest.dayNumber === startedGame.currentDay,
+    );
+    const uploaded = await uploads.saveBrowserFile(
+      new File(["proof"], "proof.png", { type: "image/png" }),
+    );
+
+    expect(blobPutMock).toHaveBeenCalledTimes(1);
+
+    await store.updateGame(game.id, (current) => {
+      submitEvidence(current, mauri!.id, mauriQuest!.id, {
+        description: "Blob upload proof",
+        kind: "photo",
+        assetUrl: uploaded.assetUrl,
+        fileName: uploaded.fileName,
+      });
+
+      return validateQuest(current, seba!.id, mauriQuest!.id, {
+        decision: "approved",
+        note: "Approved in production mode",
+      });
+    });
+
+    const validated = await store.getGame(game.id);
+    const completedQuest = validated?.quests.find((quest) => quest.id === mauriQuest!.id);
+
+    expect(validated?.players).toHaveLength(3);
+    expect(
+      validated?.players.find((player) => player.id === game.hostPlayerId)?.name,
+    ).toBe("Fede");
+    expect(completedQuest?.status).toBe("completed");
+    expect(completedQuest?.evidence?.assetUrl).toContain("blob.vercel-storage.com");
+
+    const inviteGame = await store.getGameByInvite(game.inviteCode);
+    expect(inviteGame?.id).toBe(game.id);
+
+    await store.updateGame(game.id, (current) => finishGame(current));
+
+    const finished = await store.getGame(game.id);
+    expect(finished?.status).toBe("finished");
+  });
+});

--- a/src/test/route-helpers.ts
+++ b/src/test/route-helpers.ts
@@ -1,0 +1,33 @@
+export function jsonRequest(
+  url: string,
+  body?: Record<string, unknown>,
+  init?: RequestInit,
+) {
+  return new Request(url, {
+    method: body ? "POST" : init?.method ?? "GET",
+    headers: body
+      ? {
+          "Content-Type": "application/json",
+          ...init?.headers,
+        }
+      : init?.headers,
+    body: body ? JSON.stringify(body) : init?.body,
+    ...init,
+  });
+}
+
+export function formRequest(url: string, formData: FormData, init?: RequestInit) {
+  return new Request(url, {
+    method: "POST",
+    body: formData,
+    ...init,
+  });
+}
+
+export function routeContext<TParams extends Record<string, string>>(params: TParams) {
+  return { params: Promise.resolve(params) };
+}
+
+export async function readJson<T>(response: Response) {
+  return (await response.json()) as T;
+}

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -3,6 +3,11 @@ import React from "react";
 import { afterEach, beforeAll, vi } from "vitest";
 import { cleanup } from "@testing-library/react";
 
+export const mockRouter = {
+  push: vi.fn(),
+  refresh: vi.fn(),
+};
+
 beforeAll(() => {
   Object.defineProperty(window, "matchMedia", {
     writable: true,
@@ -22,6 +27,11 @@ beforeAll(() => {
     clipboard: {
       writeText: vi.fn(),
     },
+  });
+
+  Object.defineProperty(window, "confirm", {
+    writable: true,
+    value: vi.fn(() => true),
   });
 });
 
@@ -54,8 +64,5 @@ vi.mock("next/link", () => ({
 }));
 
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: vi.fn(),
-    refresh: vi.fn(),
-  }),
+  useRouter: () => mockRouter,
 }));


### PR DESCRIPTION
## What changed
- add functional UI tests for game creation, joining, host controls, and invite-link copying
- add route-level end-to-end tests for the common game lifecycle against local filesystem storage
- add a mocked production-infrastructure test suite for Postgres- and Blob-backed flows
- add a local pre-commit hook that runs the functional and end-to-end test suites
- expand the README with local and production Telegram-ready setup guidance
- move future Telegram delivery work into issue #6 and remove that backlog section from the README

## Why
The game now has broader flow coverage for the paths people use most often, and the local git hook makes that coverage part of the normal development loop. The README is also clearer about what Telegram setup exists today versus what still needs implementation.

## User and developer impact
- developers can validate core game flows locally with one command or automatically before commits
- the most common lifecycle paths are now covered in both local and production-shaped test environments
- Telegram setup docs are easier to follow for both local and hosted deployments
- future Telegram bot delivery work is tracked in GitHub instead of living as a long README backlog section

## Validation
- `npm run test:precommit`
- `npm run lint`
- `npm run build`
