### PR TITLE
[codex] Add game resume and leave flows

### DIFF
--- a/src/app/api/games/[gameId]/players/[playerId]/route.ts
+++ b/src/app/api/games/[gameId]/players/[playerId]/route.ts
@@ -1,0 +1,29 @@
+import { NextResponse } from "next/server";
+import { leaveGame } from "@/lib/game-engine";
+import { jsonError } from "@/lib/route-response";
+import { assertSimulatorEnabled } from "@/lib/storage-config";
+import { getGame, updateGame } from "@/lib/store";
+
+export async function DELETE(
+  _request: Request,
+  context: { params: Promise<{ gameId: string; playerId: string }> },
+) {
+  try {
+    const { gameId, playerId } = await context.params;
+    const game = await getGame(gameId);
+
+    if (!game) {
+      return NextResponse.json({ error: "Game not found." }, { status: 404 });
+    }
+
+    if (game.accessMode === "simulator") {
+      assertSimulatorEnabled();
+    }
+
+    await updateGame(gameId, (current) => leaveGame(current, playerId));
+
+    return NextResponse.json({ ok: true, gameId, playerId });
+  } catch (error) {
+    return jsonError(error);
+  }
+}

--- a/src/app/api/games/route.ts
+++ b/src/app/api/games/route.ts
@@ -1,9 +1,51 @@
 import { NextResponse } from "next/server";
-import { createGame } from "@/lib/game-engine";
+import { createGame, normalizeTelegramHandle } from "@/lib/game-engine";
 import { jsonError } from "@/lib/route-response";
 import { assertSimulatorEnabled } from "@/lib/storage-config";
-import { saveGame } from "@/lib/store";
+import { listGamesForTelegramHandle, saveGame } from "@/lib/store";
 import { CreateGameInput } from "@/lib/types";
+
+export const dynamic = "force-dynamic";
+
+export async function GET(request: Request) {
+  try {
+    const { searchParams } = new URL(request.url);
+    const telegramHandle = normalizeTelegramHandle(
+      searchParams.get("telegramHandle") ?? "",
+    );
+
+    if (!telegramHandle) {
+      return NextResponse.json(
+        { error: "A Telegram handle is required." },
+        { status: 400 },
+      );
+    }
+
+    const games = await listGamesForTelegramHandle(telegramHandle);
+
+    return NextResponse.json({
+      games: games.map(({ game, player }) => ({
+        accessMode: game.accessMode,
+        currentDay: game.currentDay,
+        endDate: game.endDate,
+        gameId: game.id,
+        hostName:
+          game.players.find((entry) => entry.id === game.hostPlayerId)?.name ??
+          "Host",
+        joinedAt: player.joinedAt,
+        playerId: player.id,
+        playerName: player.name,
+        startDate: game.startDate,
+        status: game.status,
+        title: game.title,
+        totalDays: game.totalDays,
+        updatedAt: game.updatedAt,
+      })),
+    });
+  } catch (error) {
+    return jsonError(error);
+  }
+}
 
 export async function POST(request: Request) {
   try {

--- a/src/components/GameClient.controls.test.tsx
+++ b/src/components/GameClient.controls.test.tsx
@@ -99,4 +99,28 @@ describe("GameClient host controls", () => {
     );
     expect(screen.getByText(/invite copied/i)).toBeInTheDocument();
   });
+
+  it("lets a non-host player leave the game from the dashboard", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue(new Response(JSON.stringify({ ok: true })));
+    const game = buildLobbyGame();
+    const seba = game.players.find((player) => player.name === "Seba")!;
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<GameClient game={game} currentPlayer={seba} />);
+
+    await user.click(screen.getByRole("button", { name: /leave game/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith(
+        `/api/games/${game.id}/players/${seba.id}`,
+        expect.objectContaining({
+          method: "DELETE",
+        }),
+      );
+    });
+
+    expect(mockRouter.push).toHaveBeenCalledWith("/");
+  });
 });

--- a/src/components/GameClient.tsx
+++ b/src/components/GameClient.tsx
@@ -174,6 +174,7 @@ export function GameClient({
   const activeBeat =
     journey[Math.max(game.currentDay - 1, 0)] ?? journey[journey.length - 1];
   const isHost = currentPlayer?.id === game.hostPlayerId;
+  const canLeaveGame = Boolean(currentPlayer && !isHost);
   const canManageGame = isHost || game.accessMode === "simulator";
   const finaleToken = game.status === "finished" ? `${game.id}:${game.updatedAt}` : null;
   const showFinaleCinematic =
@@ -969,6 +970,32 @@ export function GameClient({
           <h1>{game.title}</h1>
           <p>{activeBeat.narratorLead}</p>
           <div className={styles.heroActions}>
+            {canLeaveGame && currentPlayer ? (
+              <button
+                type="button"
+                className={styles.ghostButton}
+                disabled={isPending}
+                onClick={() => {
+                  if (!window.confirm("Leave this game and clear your player slot from the roster?")) {
+                    return;
+                  }
+
+                  startTransition(async () => {
+                    await runJsonAction(
+                      `/api/games/${game.id}/players/${currentPlayer.id}`,
+                      undefined,
+                      {
+                        method: "DELETE",
+                        redirectTo:
+                          game.accessMode === "simulator" ? "/simulator" : "/",
+                      },
+                    );
+                  });
+                }}
+              >
+                Leave game
+              </button>
+            ) : null}
             <button type="button" onClick={() => void handleCopyInvite()}>
               Copy invite link
             </button>

--- a/src/components/HomeClient.test.tsx
+++ b/src/components/HomeClient.test.tsx
@@ -62,4 +62,48 @@ describe("HomeClient", () => {
     ).toHaveAttribute("href", "https://t.me/pixel_party_bot");
     expect(screen.getByText(/current bot: @pixel_party_bot/i)).toBeInTheDocument();
   });
+
+  it("looks up joined games by telegram handle and resumes the selected run", async () => {
+    const user = userEvent.setup();
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          games: [
+            {
+              accessMode: "telegram",
+              currentDay: 2,
+              endDate: "2026-03-30",
+              gameId: "game_456",
+              hostName: "Fede",
+              joinedAt: "2026-03-27T00:00:00.000Z",
+              playerId: "player_456",
+              playerName: "Seba",
+              startDate: "2026-03-27",
+              status: "active",
+              title: "Weekend of Bad Decisions",
+              totalDays: 4,
+              updatedAt: "2026-03-28T00:00:00.000Z",
+            },
+          ],
+        }),
+      ),
+    );
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<HomeClient showSimulatorLink />);
+
+    await user.type(screen.getByRole("textbox", { name: /^telegram handle$/i }), "@seba");
+    await user.click(screen.getByRole("button", { name: /find my games/i }));
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledWith("/api/games?telegramHandle=%40seba");
+    });
+
+    expect(screen.getByText("Weekend of Bad Decisions")).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /resume play/i }));
+
+    expect(mockRouter.push).toHaveBeenCalledWith("/game/game_456?player=player_456");
+  });
 });

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState, useTransition } from "react";
 import { listStoryBeats } from "@/lib/story";
+import type { JoinedGameSummary } from "@/lib/types";
 import styles from "./home-client.module.css";
 
 function offsetDate(days: number) {
@@ -35,11 +36,15 @@ export function HomeClient({
   telegramBotUsername?: string | null;
 }) {
   const router = useRouter();
-  const [error, setError] = useState("");
-  const [isPending, startTransition] = useTransition();
+  const [createError, setCreateError] = useState("");
+  const [resumeError, setResumeError] = useState("");
+  const [resumeResults, setResumeResults] = useState<JoinedGameSummary[]>([]);
+  const [searchedHandle, setSearchedHandle] = useState("");
+  const [isCreatePending, startCreateTransition] = useTransition();
+  const [isLookupPending, startLookupTransition] = useTransition();
 
   async function handleCreate(formData: FormData) {
-    setError("");
+    setCreateError("");
 
     const payload = {
       title: String(formData.get("title") ?? "").trim() || DEFAULT_GAME_TITLE,
@@ -56,7 +61,7 @@ export function HomeClient({
       ].filter(Boolean),
     };
 
-    startTransition(async () => {
+    startCreateTransition(async () => {
       const response = await fetch("/api/games", {
         method: "POST",
         headers: {
@@ -72,12 +77,47 @@ export function HomeClient({
       };
 
       if (!response.ok || !data.gameId || !data.hostPlayerId) {
-        setError(data.error ?? "Could not create the game.");
+        setCreateError(data.error ?? "Could not create the game.");
         return;
       }
 
       router.push(`/game/${data.gameId}?player=${data.hostPlayerId}`);
     });
+  }
+
+  async function handleResumeLookup(formData: FormData) {
+    const telegramHandle = String(formData.get("telegramHandle") ?? "").trim();
+
+    setResumeError("");
+    setSearchedHandle(telegramHandle);
+
+    const response = await fetch(
+      `/api/games?telegramHandle=${encodeURIComponent(telegramHandle)}`,
+    );
+    const data = (await response.json()) as {
+      error?: string;
+      games?: JoinedGameSummary[];
+    };
+
+    if (!response.ok) {
+      setResumeResults([]);
+      setResumeError(data.error ?? "Could not look up your games.");
+      return;
+    }
+
+    setResumeResults(data.games ?? []);
+  }
+
+  function formatResumeState(game: JoinedGameSummary) {
+    if (game.status === "lobby") {
+      return "Lobby open";
+    }
+
+    if (game.status === "finished") {
+      return "Finished";
+    }
+
+    return `Day ${game.currentDay} of ${game.totalDays}`;
   }
 
   return (
@@ -185,62 +225,123 @@ export function HomeClient({
 
       <section id="create" className={styles.formSection}>
         <div className={styles.sectionHeading}>
-          <p className={styles.eyebrow}>Create A Game Instance</p>
-          <h2>Open the lobby, set the trip window, and get a public join link.</h2>
+          <p className={styles.eyebrow}>Create Or Resume</p>
+          <h2>Open a new lobby or pull up every game already tied to your Telegram handle.</h2>
         </div>
-        <form
-          className={styles.formCard}
-          onSubmit={(event) => {
-            event.preventDefault();
-            void handleCreate(new FormData(event.currentTarget));
-          }}
-        >
-          <label>
-            Game title
-            <input name="title" placeholder={DEFAULT_GAME_TITLE} />
-          </label>
-          <label>
-            Groom name
-            <input name="groomName" placeholder={DEFAULT_GROOM_NAME} />
-          </label>
-          <label>
-            Host name
-            <input name="hostName" placeholder={DEFAULT_HOST_NAME} />
-          </label>
-          <label>
-            Host Telegram
-            <input name="telegramHandle" placeholder="@fede" required />
-          </label>
-          <div className={styles.dateRow}>
-            <label>
-              Start date
-              <input name="startDate" type="date" defaultValue={offsetDate(0)} required />
-            </label>
-            <label>
-              End date
-              <input name="endDate" type="date" defaultValue={offsetDate(3)} required />
-            </label>
+        <div className={styles.formGrid}>
+          <div className={`${styles.formCard} ${styles.resumeCard}`}>
+            <div className={styles.sectionHeading}>
+              <p className={styles.eyebrow}>Resume A Game</p>
+              <h3>See every lobby or run you already joined.</h3>
+            </div>
+            <p className={styles.summary}>
+              Enter the same Telegram handle you used when you joined. We&apos;ll list
+              every matching game so you can jump back in without hunting for the old
+              URL.
+            </p>
+            <form
+              className={styles.lookupForm}
+              onSubmit={(event) => {
+                event.preventDefault();
+                startLookupTransition(async () => {
+                  await handleResumeLookup(new FormData(event.currentTarget));
+                });
+              }}
+            >
+              <label>
+                Telegram handle
+                <input name="telegramHandle" placeholder="@luqui" required />
+              </label>
+              <button type="submit" disabled={isLookupPending}>
+                {isLookupPending ? "Looking up games..." : "Find my games"}
+              </button>
+            </form>
+            {resumeError ? <p className={styles.error}>{resumeError}</p> : null}
+            {resumeResults.length > 0 ? (
+              <div className={styles.resumeList}>
+                {resumeResults.map((game) => (
+                  <article key={`${game.gameId}:${game.playerId}`} className={styles.resumeItem}>
+                    <div className={styles.resumeMeta}>
+                      <strong>{game.title}</strong>
+                      <span>{formatResumeState(game)}</span>
+                      <span>{`${game.startDate} to ${game.endDate}`}</span>
+                      <span>{`You joined as ${game.playerName}`}</span>
+                      <span>{`Host: ${game.hostName}`}</span>
+                    </div>
+                    <button
+                      type="button"
+                      className={styles.secondaryAction}
+                      onClick={() => {
+                        router.push(`/game/${game.gameId}?player=${game.playerId}`);
+                      }}
+                    >
+                      Resume play
+                    </button>
+                  </article>
+                ))}
+              </div>
+            ) : null}
+            {searchedHandle && !resumeError && !isLookupPending && resumeResults.length === 0 ? (
+              <p className={styles.emptyState}>
+                No games found for {searchedHandle}. Join a game from an invite link first.
+              </p>
+            ) : null}
           </div>
-          <fieldset className={styles.tagFieldset}>
-            <legend>Quest spice level</legend>
-            <label className={styles.tagLabel}>
-              <input type="checkbox" name="tag_alcohol" defaultChecked />
-              Alcohol quests
+
+          <form
+            className={styles.formCard}
+            onSubmit={(event) => {
+              event.preventDefault();
+              void handleCreate(new FormData(event.currentTarget));
+            }}
+          >
+            <label>
+              Game title
+              <input name="title" placeholder={DEFAULT_GAME_TITLE} />
             </label>
-            <label className={styles.tagLabel}>
-              <input type="checkbox" name="tag_locuras" defaultChecked />
-              Wild dares
+            <label>
+              Groom name
+              <input name="groomName" placeholder={DEFAULT_GROOM_NAME} />
             </label>
-            <label className={styles.tagLabel}>
-              <input type="checkbox" name="tag_vegas" />
-              Vegas rules (no-filter confessions)
+            <label>
+              Host name
+              <input name="hostName" placeholder={DEFAULT_HOST_NAME} />
             </label>
-          </fieldset>
-          {error ? <p className={styles.error}>{error}</p> : null}
-          <button type="submit" disabled={isPending}>
-            {isPending ? "Opening lobby..." : "Create Telegram-Ready Game"}
-          </button>
-        </form>
+            <label>
+              Host Telegram
+              <input name="telegramHandle" placeholder="@fede" required />
+            </label>
+            <div className={styles.dateRow}>
+              <label>
+                Start date
+                <input name="startDate" type="date" defaultValue={offsetDate(0)} required />
+              </label>
+              <label>
+                End date
+                <input name="endDate" type="date" defaultValue={offsetDate(3)} required />
+              </label>
+            </div>
+            <fieldset className={styles.tagFieldset}>
+              <legend>Quest spice level</legend>
+              <label className={styles.tagLabel}>
+                <input type="checkbox" name="tag_alcohol" defaultChecked />
+                Alcohol quests
+              </label>
+              <label className={styles.tagLabel}>
+                <input type="checkbox" name="tag_locuras" defaultChecked />
+                Wild dares
+              </label>
+              <label className={styles.tagLabel}>
+                <input type="checkbox" name="tag_vegas" />
+                Vegas rules (no-filter confessions)
+              </label>
+            </fieldset>
+            {createError ? <p className={styles.error}>{createError}</p> : null}
+            <button type="submit" disabled={isCreatePending}>
+              {isCreatePending ? "Opening lobby..." : "Create Telegram-Ready Game"}
+            </button>
+          </form>
+        </div>
       </section>
     </div>
   );

--- a/src/components/home-client.module.css
+++ b/src/components/home-client.module.css
@@ -166,6 +166,13 @@
   gap: 1.3rem;
 }
 
+.formGrid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: minmax(18rem, 0.85fr) minmax(0, 1.15fr);
+  align-items: start;
+}
+
 .sectionHeading {
   display: grid;
   gap: 0.55rem;
@@ -207,10 +214,31 @@
 .formCard {
   display: grid;
   gap: 1rem;
-  max-width: 48rem;
   padding: 1.4rem;
   background: rgba(17, 23, 43, 0.94);
   color: #fff6df;
+}
+
+.resumeCard {
+  background: linear-gradient(180deg, rgba(255, 248, 233, 0.97), rgba(255, 228, 182, 0.96));
+  color: #141a33;
+}
+
+.resumeCard .summary,
+.resumeMeta span,
+.emptyState {
+  color: #28304b;
+}
+
+.resumeCard .eyebrow,
+.resumeCard h3 {
+  color: #141a33;
+}
+
+.resumeCard h3 {
+  font-family: var(--font-display);
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  line-height: 1.1;
 }
 
 .formCard label {
@@ -226,6 +254,47 @@
   color: #fff6df;
   background: rgba(255, 255, 255, 0.08);
   border: 2px solid rgba(255, 246, 223, 0.28);
+}
+
+.resumeCard input {
+  color: #141a33;
+  background: rgba(255, 255, 255, 0.74);
+  border-color: rgba(20, 26, 51, 0.22);
+}
+
+.lookupForm,
+.resumeList,
+.resumeMeta {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.resumeItem {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem;
+  background: rgba(255, 255, 255, 0.62);
+  border: 2px solid rgba(20, 26, 51, 0.22);
+}
+
+.resumeMeta strong {
+  font-family: var(--font-display);
+  font-size: 1.05rem;
+  color: #141a33;
+}
+
+.resumeMeta span {
+  width: fit-content;
+  padding: 0.3rem 0.5rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  background: rgba(20, 26, 51, 0.08);
+  border: 1px solid rgba(20, 26, 51, 0.14);
+}
+
+.emptyState {
+  line-height: 1.5;
 }
 
 .dateRow {
@@ -270,6 +339,7 @@
 
 @media (max-width: 900px) {
   .hero,
+  .formGrid,
   .strip,
   .dateRow {
     grid-template-columns: 1fr;

--- a/src/lib/game-engine.test.ts
+++ b/src/lib/game-engine.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resetGame, validateQuest } from "@/lib/game-engine";
+import { leaveGame, resetGame, validateQuest } from "@/lib/game-engine";
 import {
   buildStartedSimulatorGame,
   buildStartedTelegramGame,
@@ -78,6 +78,24 @@ describe("game validation flow", () => {
         note: "Self-approved",
       }),
     ).toThrow("cannot validate your own quest");
+  });
+
+  it("lets a non-host player leave and removes their active progress", () => {
+    const { game, mauri } = buildStartedTelegramGame();
+
+    const updatedGame = leaveGame(game, mauri.id);
+
+    expect(updatedGame.players.some((player) => player.id === mauri.id)).toBe(false);
+    expect(updatedGame.quests.some((quest) => quest.playerId === mauri.id)).toBe(false);
+    expect(updatedGame.messages.at(-1)?.title).toBe("Party member left");
+  });
+
+  it("blocks the host from leaving the game", () => {
+    const { game, host } = buildStartedTelegramGame();
+
+    expect(() => leaveGame(game, host.id)).toThrow(
+      "The host cannot leave the game. Delete the game instead.",
+    );
   });
 
   it("resets a game back to the lobby while keeping the roster", () => {

--- a/src/lib/game-engine.ts
+++ b/src/lib/game-engine.ts
@@ -67,7 +67,7 @@ function toTitleCase(value: string) {
     .join(" ");
 }
 
-function sanitizeTelegramHandle(value?: string) {
+export function normalizeTelegramHandle(value?: string) {
   const normalized = value?.trim().replace(/^@/, "") ?? "";
   return normalized ? `@${normalized}` : "";
 }
@@ -121,7 +121,7 @@ function createPlayer(
   return {
     id: createId("player"),
     name: toTitleCase(name.trim()),
-    telegramHandle: sanitizeTelegramHandle(telegramHandle),
+    telegramHandle: normalizeTelegramHandle(telegramHandle),
     telegramBindingToken: createBindingToken(),
     joinedAt: now(),
     points: 0,
@@ -280,7 +280,7 @@ export function createGame(input: CreateGameInput): Game {
 
   if (
     input.accessMode === "telegram" &&
-    !sanitizeTelegramHandle(input.telegramHandle)
+    !normalizeTelegramHandle(input.telegramHandle)
   ) {
     throw new Error("The host needs a Telegram handle for the web game.");
   }
@@ -342,7 +342,7 @@ export function joinGame(game: Game, input: JoinGameInput) {
 
   if (
     game.accessMode === "telegram" &&
-    !sanitizeTelegramHandle(input.telegramHandle)
+    !normalizeTelegramHandle(input.telegramHandle)
   ) {
     throw new Error("A Telegram handle is required for the web game.");
   }
@@ -372,6 +372,34 @@ export function joinGame(game: Game, input: JoinGameInput) {
 
   game.updatedAt = now();
   return { game, player };
+}
+
+export function leaveGame(game: Game, playerId: string) {
+  const player = game.players.find((entry) => entry.id === playerId);
+
+  if (!player) {
+    throw new Error("Player not found.");
+  }
+
+  if (player.id === game.hostPlayerId) {
+    throw new Error("The host cannot leave the game. Delete the game instead.");
+  }
+
+  game.players = game.players.filter((entry) => entry.id !== playerId);
+  game.quests = game.quests.filter((quest) => quest.playerId !== playerId);
+  game.finaleCards = game.finaleCards.filter((card) => card.playerId !== playerId);
+
+  addMessages(game, [
+    createMessage(
+      "Party member left",
+      `${player.name} left the game and their active progress was cleared from the roster.`,
+      "all",
+      "timeline",
+    ),
+  ]);
+
+  game.updatedAt = now();
+  return game;
 }
 
 export function startGame(game: Game) {

--- a/src/lib/store.ts
+++ b/src/lib/store.ts
@@ -1,7 +1,8 @@
 import { promises as fs } from "fs";
 import path from "path";
 import postgres, { type Sql } from "postgres";
-import { Game } from "@/lib/types";
+import { normalizeTelegramHandle } from "@/lib/game-engine";
+import { Game, Player } from "@/lib/types";
 import {
   assertGameStorageAvailable,
   getDatabaseUrl,
@@ -265,6 +266,29 @@ export async function listGames() {
   return Object.values(store.games).sort((left, right) =>
     right.createdAt.localeCompare(left.createdAt),
   );
+}
+
+export async function listGamesForTelegramHandle(telegramHandle: string) {
+  const normalizedHandle = normalizeTelegramHandle(telegramHandle);
+
+  if (!normalizedHandle) {
+    return [] as Array<{ game: Game; player: Player }>;
+  }
+
+  const games = await listGames();
+
+  return games.flatMap((game) => {
+    if (game.accessMode !== "telegram") {
+      return [];
+    }
+
+    const player = game.players.find(
+      (entry) =>
+        entry.telegramHandle.toLowerCase() === normalizedHandle.toLowerCase(),
+    );
+
+    return player ? [{ game, player }] : [];
+  });
 }
 
 export async function getGame(gameId: string) {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -103,6 +103,22 @@ export interface FinaleCard {
 
 export type QuestTagToggle = "alcohol" | "locuras" | "vegas";
 
+export interface JoinedGameSummary {
+  accessMode: AccessMode;
+  currentDay: number;
+  endDate: string;
+  gameId: string;
+  hostName: string;
+  joinedAt: string;
+  playerId: string;
+  playerName: string;
+  startDate: string;
+  status: GameStatus;
+  title: string;
+  totalDays: number;
+  updatedAt: string;
+}
+
 export interface Game {
   id: string;
   inviteCode: string;


### PR DESCRIPTION
## What changed
- added a homepage lookup flow that lets players enter their Telegram handle and see every game they have joined
- added a resume action from the homepage so players can jump back into the correct gameplay URL without remembering it
- added a player leave-game action and server route so non-host players can remove themselves from a game
- added store and engine support for Telegram-handle lookup and player removal
- added coverage for the new home-page resume flow and leave-game behavior

## Why
Players previously had to remember or preserve each gameplay URL manually. This change lets them recover their active or past game sessions from the homepage using the Telegram handle they already used to join.

## Impact
- players can resume games from the homepage
- non-host players can leave a game directly from the dashboard
- hosts retain ownership and cannot accidentally orphan a game by leaving

## Validation
- `npm run test:precommit`
- `npm run lint -- src/components/HomeClient.test.tsx src/lib/game-engine.ts src/components/HomeClient.tsx src/app/api/games/route.ts src/components/GameClient.tsx`

## Root cause
The app had create and join flows, but no recovery path for returning players and no self-service way for a player to exit a game once joined.