### PR TITLE
[codex] Fix Vercel sync workflow secret env types

### DIFF
--- a/.github/workflows/sync_env_variables.yml
+++ b/.github/workflows/sync_env_variables.yml
@@ -74,7 +74,7 @@ jobs:
             }
           }
 
-          await upsert("TELEGRAM_BOT_TOKEN", process.env.TELEGRAM_BOT_TOKEN, "secret");
+          await upsert("TELEGRAM_BOT_TOKEN", process.env.TELEGRAM_BOT_TOKEN, "sensitive");
           await upsert("TELEGRAM_BOT_USERNAME", process.env.TELEGRAM_BOT_USERNAME, "plain");
           await upsert(
             "NEXT_PUBLIC_TELEGRAM_BOT_USERNAME",
@@ -84,12 +84,12 @@ jobs:
           await upsert(
             "TELEGRAM_WEBHOOK_SECRET_TOKEN",
             process.env.TELEGRAM_WEBHOOK_SECRET_TOKEN,
-            "secret",
+            "sensitive",
           );
           await upsert(
             "TELEGRAM_BINDING_ENCRYPTION_KEY",
             process.env.TELEGRAM_BINDING_ENCRYPTION_KEY,
-            "secret",
+            "sensitive",
           );
           await upsert("APP_URL", process.env.APP_URL, "plain");
           await upsert("NEXT_PUBLIC_APP_URL", process.env.APP_URL, "plain");


### PR DESCRIPTION
## What changed
- switched the protected Vercel env upserts in the sync workflow from `type: "secret"` to `type: "sensitive"`
- left public values as `plain`

## Why
The GitHub Actions sync job was failing when calling Vercel's project env API. Vercel now expects raw protected values to be created as sensitive environment variables rather than legacy secret references.

## Impact
This lets the `Sync Repository Secrets To Vercel Env` workflow update Telegram-related protected variables in Vercel again.

## Root cause
The workflow posted raw secret values with `type: "secret"`, and Vercel rejected them with `ENV_SHOULD_BE_A_SECRET` because only secret IDs are accepted for that legacy path.

## Validation
- `git diff --cached --check`
- pre-commit hook:
  - `npm run test:functional`
  - `npm run test:e2e`
