### PR TITLE
[codex] Make start-game blocker visible near host controls

### DIFF
--- a/src/components/GameClient.controls.test.tsx
+++ b/src/components/GameClient.controls.test.tsx
@@ -22,6 +22,22 @@ function buildLobbyGame() {
   return game;
 }
 
+function buildInsufficientLobbyGame() {
+  const game = createGame({
+    title: "Host Controls",
+    groomName: "Tincho",
+    hostName: "Fede",
+    telegramHandle: "@fede",
+    startDate: "2026-03-27",
+    endDate: "2026-03-30",
+    accessMode: "telegram",
+  });
+
+  joinGame(game, { name: "Mauri", telegramHandle: "@mauri" });
+
+  return game;
+}
+
 describe("GameClient host controls", () => {
   it("starts a lobby game from the host controls", async () => {
     const user = userEvent.setup();
@@ -45,6 +61,21 @@ describe("GameClient host controls", () => {
     });
 
     expect(mockRouter.refresh).toHaveBeenCalled();
+  });
+
+  it("shows the minimum player requirement next to the start button", () => {
+    const game = buildInsufficientLobbyGame();
+    const host = game.players.find((player) => player.id === game.hostPlayerId)!;
+
+    render(<GameClient game={game} currentPlayer={host} />);
+
+    expect(
+      screen.getByRole("button", { name: /start game and trigger day 1/i }),
+    ).toBeDisabled();
+    expect(
+      screen.getByText(/need at least 3 players to start\./i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/1 more player needs to join\./i)).toBeInTheDocument();
   });
 
   it("advances the day and can end the game early for the host", async () => {

--- a/src/components/GameClient.tsx
+++ b/src/components/GameClient.tsx
@@ -169,6 +169,11 @@ export function GameClient({
     journey[Math.max(game.currentDay - 1, 0)] ?? journey[journey.length - 1];
   const isHost = currentPlayer?.id === game.hostPlayerId;
   const canManageGame = isHost || game.accessMode === "simulator";
+  const minimumPlayersToStart = 3;
+  const missingPlayersToStart = Math.max(minimumPlayersToStart - game.players.length, 0);
+  const cannotStartGame =
+    isHost && game.status === "lobby" && missingPlayersToStart > 0;
+  const showInlineHostError = Boolean(error) && canManageGame;
   const finaleToken = game.status === "finished" ? `${game.id}:${game.updatedAt}` : null;
   const showFinaleCinematic =
     finaleToken !== null && dismissedFinaleToken !== finaleToken;
@@ -974,17 +979,34 @@ export function GameClient({
                   </button>
                 ) : null}
                 {isHost && game.status === "lobby" ? (
-                  <button
-                    type="button"
-                    disabled={isPending}
-                    onClick={() =>
-                      startTransition(async () => {
-                        await runJsonAction(`/api/games/${game.id}/start`);
-                      })
-                    }
-                  >
-                    Start game and trigger day 1
-                  </button>
+                  <div className={styles.startActionGroup}>
+                    <button
+                      type="button"
+                      disabled={isPending || cannotStartGame}
+                      aria-describedby={
+                        cannotStartGame ? "start-game-minimum-players" : undefined
+                      }
+                      onClick={() =>
+                        startTransition(async () => {
+                          await runJsonAction(`/api/games/${game.id}/start`);
+                        })
+                      }
+                    >
+                      Start game and trigger day 1
+                    </button>
+                    {cannotStartGame ? (
+                      <p
+                        id="start-game-minimum-players"
+                        className={styles.startActionHint}
+                        role="status"
+                      >
+                        Need at least 3 players to start.{" "}
+                        {missingPlayersToStart === 1
+                          ? "1 more player needs to join."
+                          : `${missingPlayersToStart} more players need to join.`}
+                      </p>
+                    ) : null}
+                  </div>
                 ) : null}
                 {isHost && game.status === "active" ? (
                   <button
@@ -1067,6 +1089,12 @@ export function GameClient({
                   </button>
                 ) : null}
               </div>
+              {showInlineHostError ? (
+                <article className={`${styles.errorPanel} ${styles.inlineErrorPanel}`}>
+                  <strong>Action blocked</strong>
+                  <p>{error}</p>
+                </article>
+              ) : null}
             </div>
           ) : null}
           <div className={styles.heroMeta}>
@@ -1093,7 +1121,7 @@ export function GameClient({
 
         <section className={styles.feedRail}>
           {renderNarratorFeed(currentPlayer, visibleMessages)}
-          {error ? (
+          {error && !showInlineHostError ? (
             <article className={styles.errorPanel}>
               <strong>Action blocked</strong>
               <p>{error}</p>
@@ -1113,7 +1141,7 @@ export function GameClient({
             {renderTripMap()}
             {renderRoster()}
           </div>
-          {error ? (
+          {error && !showInlineHostError ? (
             <article className={styles.errorPanel}>
               <strong>Action blocked</strong>
               <p>{error}</p>

--- a/src/components/game-client.module.css
+++ b/src/components/game-client.module.css
@@ -160,6 +160,20 @@
   border: 2px solid rgba(255, 247, 230, 0.24);
 }
 
+.startActionGroup {
+  display: grid;
+  gap: 0.45rem;
+}
+
+.startActionHint {
+  max-width: 28ch;
+  padding: 0.7rem 0.8rem;
+  line-height: 1.45;
+  color: #fff7e6;
+  background: rgba(255, 93, 61, 0.22);
+  border: 2px solid rgba(255, 196, 98, 0.48);
+}
+
 .validationMenu {
   gap: 0.9rem;
   padding: 1rem;
@@ -635,6 +649,10 @@
 
 .errorPanel {
   background: rgba(255, 226, 214, 0.96);
+}
+
+.inlineErrorPanel {
+  margin-top: 0.25rem;
 }
 
 .desktopSplitView {


### PR DESCRIPTION
## What changed
- disabled the host start button when the lobby has fewer than 3 players
- added an inline requirement message directly under the start action so the blocker is visible where the user clicks
- kept action-blocked errors near the host controls instead of only surfacing them in the side rail
- added a focused control test covering the under-3-player lobby case

## Why
Starting from a lobby with fewer than 3 players was blocked by the backend, but the UI feedback lived far from the start button. That made the failure easy to miss and disconnected from the action that triggered it.

## Impact
Hosts now see the requirement immediately in the controls area, with the remaining player count spelled out before they try to start the game.

## Validation
- npm run test -- src/components/GameClient.controls.test.tsx
- npm run lint -- src/components/GameClient.tsx src/components/GameClient.controls.test.tsx
- pre-commit hook: npm run test:precommit
