### PR TITLE
[codex] Remove Telegram bot landing CTA

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,12 +1,11 @@
 import { HomeClient } from "@/components/HomeClient";
 import { isSimulatorEnabled } from "@/lib/storage-config";
-import { getTelegramBotUrl, getTelegramBotUsername } from "@/lib/telegram";
+import { getTelegramBotUsername } from "@/lib/telegram";
 
 export default function Home() {
   return (
     <HomeClient
       showSimulatorLink={isSimulatorEnabled()}
-      telegramBotUrl={getTelegramBotUrl()}
       telegramBotUsername={getTelegramBotUsername()}
     />
   );

--- a/src/components/HomeClient.test.tsx
+++ b/src/components/HomeClient.test.tsx
@@ -89,18 +89,15 @@ describe("HomeClient", () => {
     expect(payload.telegramChatId).toBe("1001");
   });
 
-  it("renders the Telegram bot link when a username is configured", () => {
+  it("renders the Telegram bot note when a username is configured", () => {
     render(
       <HomeClient
         showSimulatorLink={false}
-        telegramBotUrl="https://t.me/pixel_party_bot"
         telegramBotUsername="pixel_party_bot"
       />,
     );
 
-    expect(
-      screen.getByRole("link", { name: /open telegram bot/i }),
-    ).toHaveAttribute("href", "https://t.me/pixel_party_bot");
+    expect(screen.queryByRole("link", { name: /open telegram bot/i })).not.toBeInTheDocument();
     expect(screen.getByText(/current bot: @pixel_party_bot/i)).toBeInTheDocument();
   });
 

--- a/src/components/HomeClient.tsx
+++ b/src/components/HomeClient.tsx
@@ -29,11 +29,9 @@ const DEFAULT_HOST_NAME = "Fede";
 
 export function HomeClient({
   showSimulatorLink,
-  telegramBotUrl,
   telegramBotUsername,
 }: {
   showSimulatorLink: boolean;
-  telegramBotUrl?: string | null;
   telegramBotUsername?: string | null;
 }) {
   const router = useRouter();
@@ -140,16 +138,6 @@ export function HomeClient({
               <Link href="/simulator" className={styles.secondaryAction}>
                 Open Local Simulator
               </Link>
-            ) : null}
-            {telegramBotUrl ? (
-              <a
-                href={telegramBotUrl}
-                className={styles.secondaryAction}
-                target="_blank"
-                rel="noreferrer"
-              >
-                Open Telegram Bot
-              </a>
             ) : null}
           </div>
           <div className={styles.telegramNote}>


### PR DESCRIPTION
## What changed
- removed the landing-page "Open Telegram Bot" CTA from the home hero
- kept the Telegram note so players still see the bot username and linking guidance
- updated the home screen test to assert the CTA is gone

## Why
The button encouraged players to leave the in-game flow too early. Removing it keeps the landing experience focused on creating or joining a game instead of jumping out to Telegram.

## Impact
Players stay in the web flow until they actually need Telegram for linked delivery, which should reduce distraction and drop-off during setup.

## Validation
- `npm run test -- src/components/HomeClient.test.tsx`
- `npm run lint -- src/components/HomeClient.tsx src/components/HomeClient.test.tsx src/app/page.tsx`
- `npm run test:precommit`
