### PR TITLE
[codex] Harden evidence uploads and server logging

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,9 +10,11 @@
       "dependencies": {
         "@vercel/blob": "^2.3.1",
         "next": "16.2.1",
+        "pino": "^10.3.1",
         "postgres": "^3.4.8",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "zod": "^4.3.6"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
@@ -1476,6 +1478,12 @@
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
       }
+    },
+    "node_modules/@pinojs/redact": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
+      "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.11",
@@ -2948,6 +2956,15 @@
       "license": "MIT",
       "dependencies": {
         "retry": "0.13.1"
+      }
+    },
+    "node_modules/atomic-sleep": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+      "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/available-typed-arrays": {
@@ -6001,6 +6018,15 @@
       ],
       "license": "MIT"
     },
+    "node_modules/on-exit-leak-free": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
+      "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6148,6 +6174,43 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/pino": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/pino/-/pino-10.3.1.tgz",
+      "integrity": "sha512-r34yH/GlQpKZbU1BvFFqOjhISRo1MNx1tWYsYvmj6KIRHSPMT2+yHOEb1SG6NMvRoHRF0a07kCOox/9yakl1vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@pinojs/redact": "^0.4.0",
+        "atomic-sleep": "^1.0.0",
+        "on-exit-leak-free": "^2.1.0",
+        "pino-abstract-transport": "^3.0.0",
+        "pino-std-serializers": "^7.0.0",
+        "process-warning": "^5.0.0",
+        "quick-format-unescaped": "^4.0.3",
+        "real-require": "^0.2.0",
+        "safe-stable-stringify": "^2.3.1",
+        "sonic-boom": "^4.0.1",
+        "thread-stream": "^4.0.0"
+      },
+      "bin": {
+        "pino": "bin.js"
+      }
+    },
+    "node_modules/pino-abstract-transport": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-3.0.0.tgz",
+      "integrity": "sha512-wlfUczU+n7Hy/Ha5j9a/gZNy7We5+cXp8YL+X+PG8S0KXxw7n/JXA3c46Y0zQznIJ83URJiwy7Lh56WLokNuxg==",
+      "license": "MIT",
+      "dependencies": {
+        "split2": "^4.0.0"
+      }
+    },
+    "node_modules/pino-std-serializers": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.1.0.tgz",
+      "integrity": "sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==",
+      "license": "MIT"
+    },
     "node_modules/possible-typed-array-names": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/possible-typed-array-names/-/possible-typed-array-names-1.1.0.tgz",
@@ -6247,6 +6310,22 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/process-warning": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
+      "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -6290,6 +6369,12 @@
       ],
       "license": "MIT"
     },
+    "node_modules/quick-format-unescaped": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
+      "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "license": "MIT"
+    },
     "node_modules/react": {
       "version": "19.2.4",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
@@ -6317,6 +6402,15 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/real-require": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
+      "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12.13.0"
+      }
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -6558,6 +6652,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-stable-stringify": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
+      "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/saxes": {
@@ -6802,6 +6905,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/sonic-boom": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.1.tgz",
+      "integrity": "sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==",
+      "license": "MIT",
+      "dependencies": {
+        "atomic-sleep": "^1.0.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -6809,6 +6921,15 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/split2": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
+      "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">= 10.x"
       }
     },
     "node_modules/stable-hash": {
@@ -7050,6 +7171,18 @@
       "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/thread-stream": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-4.0.0.tgz",
+      "integrity": "sha512-4iMVL6HAINXWf1ZKZjIPcz5wYaOdPhtO8ATvZ+Xqp3BTdaqtAwQkNmKORqcIo5YkQqGXq5cwfswDwMqqQNrpJA==",
+      "license": "MIT",
+      "dependencies": {
+        "real-require": "^0.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/throttleit": {
       "version": "2.1.0",
@@ -7919,7 +8052,6 @@
       "version": "4.3.6",
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -16,9 +16,11 @@
   "dependencies": {
     "@vercel/blob": "^2.3.1",
     "next": "16.2.1",
+    "pino": "^10.3.1",
     "postgres": "^3.4.8",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",

--- a/src/app/api/games/[gameId]/quests/[questId]/evidence/route.test.ts
+++ b/src/app/api/games/[gameId]/quests/[questId]/evidence/route.test.ts
@@ -1,4 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  MAX_EVIDENCE_REQUEST_SIZE_BYTES,
+  MAX_EVIDENCE_UPLOAD_SIZE_BYTES,
+} from "@/lib/types";
+import { parseEvidenceRequest } from "@/lib/evidence-request";
 
 const updateGameMock = vi.fn();
 const deliverTelegramReadyMessagesMock = vi.fn();
@@ -91,6 +96,57 @@ describe("evidence route validation", () => {
     expect(response.status).toBe(400);
     expect(payload.error).toBe(
       "Evidence descriptions must be 500 characters or fewer.",
+    );
+    expect(updateGameMock).not.toHaveBeenCalled();
+    expect(saveBrowserFileMock).not.toHaveBeenCalled();
+    expect(deliverTelegramReadyMessagesMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized evidence requests before parsing form data", async () => {
+    const route = await import("@/app/api/games/[gameId]/quests/[questId]/evidence/route");
+
+    const response = await route.POST(
+      new Request("http://localhost/api/games/game_1/quests/quest_1/evidence", {
+        method: "POST",
+        headers: {
+          "Content-Length": String(MAX_EVIDENCE_REQUEST_SIZE_BYTES + 1),
+          "Content-Type": "multipart/form-data; boundary=codex",
+        },
+        body: "--codex--",
+      }),
+      {
+        params: Promise.resolve({
+          gameId: "game_1",
+          questId: "quest_1",
+        }),
+      },
+    );
+    const payload = (await response.json()) as { error?: string };
+
+    expect(response.status).toBe(400);
+    expect(payload.error).toBe("Evidence requests must be 10 MB or smaller.");
+    expect(updateGameMock).not.toHaveBeenCalled();
+    expect(saveBrowserFileMock).not.toHaveBeenCalled();
+    expect(deliverTelegramReadyMessagesMock).not.toHaveBeenCalled();
+  });
+
+  it("rejects oversized uploads before saving browser files", async () => {
+    const oversizedFile = new File(["x"], "proof.jpg", {
+      type: "image/jpeg",
+    });
+    const formData = new FormData();
+
+    Object.defineProperty(oversizedFile, "size", {
+      value: MAX_EVIDENCE_UPLOAD_SIZE_BYTES + 1,
+    });
+
+    formData.set("playerId", "player_1");
+    formData.set("description", "Definitely a quest proof");
+    formData.set("kind", "photo");
+    formData.set("file", oversizedFile);
+
+    expect(() => parseEvidenceRequest(formData)).toThrow(
+      "Evidence uploads must be 8 MB or smaller.",
     );
     expect(updateGameMock).not.toHaveBeenCalled();
     expect(saveBrowserFileMock).not.toHaveBeenCalled();

--- a/src/app/api/games/[gameId]/quests/[questId]/evidence/route.ts
+++ b/src/app/api/games/[gameId]/quests/[questId]/evidence/route.ts
@@ -1,4 +1,8 @@
 import { NextResponse } from "next/server";
+import {
+  assertEvidenceRequestSize,
+  parseEvidenceRequest,
+} from "@/lib/evidence-request";
 import { submitEvidence } from "@/lib/game-engine";
 import { UserFacingError } from "@/lib/errors";
 import { jsonError } from "@/lib/route-response";
@@ -10,11 +14,6 @@ import {
   getTelegramSession,
   TELEGRAM_AUTH_COOKIE_NAME,
 } from "@/lib/telegram-auth";
-import {
-  EVIDENCE_KINDS,
-  isEvidenceKind,
-  MAX_EVIDENCE_DESCRIPTION_LENGTH,
-} from "@/lib/types";
 import { saveBrowserFile } from "@/lib/uploads";
 
 export async function POST(
@@ -23,33 +22,18 @@ export async function POST(
 ) {
   try {
     const { gameId, questId } = await context.params;
+    assertEvidenceRequestSize(request);
     const formData = await request.formData();
-    const bodyPlayerId = String(formData.get("playerId") ?? "");
-    const description = String(formData.get("description") ?? "").trim();
-    const kind = String(formData.get("kind") ?? "photo");
-    const proofUrl = String(formData.get("proofUrl") ?? "");
-    const file = formData.get("file");
+    const body = parseEvidenceRequest(formData);
     const telegramSession = getTelegramSession(
       getCookieValue(request.headers.get("cookie"), TELEGRAM_AUTH_COOKIE_NAME),
     );
 
-    if (!isEvidenceKind(kind)) {
-      throw new UserFacingError(
-        `Evidence type must be one of: ${EVIDENCE_KINDS.join(", ")}.`,
-      );
-    }
-
-    if (description.length > MAX_EVIDENCE_DESCRIPTION_LENGTH) {
-      throw new UserFacingError(
-        `Evidence descriptions must be ${MAX_EVIDENCE_DESCRIPTION_LENGTH} characters or fewer.`,
-      );
-    }
-
-    let assetUrl = proofUrl.trim();
+    let assetUrl = body.proofUrl;
     let fileName: string | undefined;
 
-    if (file instanceof File && file.size > 0) {
-      const saved = await saveBrowserFile(file);
+    if (body.file) {
+      const saved = await saveBrowserFile(body.file);
       assetUrl = saved.assetUrl;
       fileName = saved.fileName;
     }
@@ -57,9 +41,13 @@ export async function POST(
     const game = await updateGame(gameId, (current) => {
       if (current.accessMode === "simulator") {
         assertSimulatorEnabled();
-        return submitEvidence(current, bodyPlayerId, questId, {
-          description,
-          kind: kind === "video" ? "video" : "photo",
+        if (!body.playerId) {
+          throw new UserFacingError("A simulator player id is required to submit evidence.");
+        }
+
+        return submitEvidence(current, body.playerId, questId, {
+          description: body.description,
+          kind: body.kind,
           assetUrl,
           fileName,
         });
@@ -73,8 +61,8 @@ export async function POST(
       }
 
       return submitEvidence(current, sessionPlayer.id, questId, {
-        description,
-        kind,
+        description: body.description,
+        kind: body.kind,
         assetUrl,
         fileName,
       });

--- a/src/app/api/games/games-route.test.ts
+++ b/src/app/api/games/games-route.test.ts
@@ -33,7 +33,20 @@ describe("games route telegram logging", () => {
           },
         ),
       );
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
+    const logWrites: string[] = [];
+    const stdoutSpy = vi.spyOn(process.stdout, "write").mockImplementation(
+      ((chunk, encoding, callback) => {
+        logWrites.push(typeof chunk === "string" ? chunk : chunk.toString());
+
+        if (typeof encoding === "function") {
+          encoding();
+        } else {
+          callback?.();
+        }
+
+        return true;
+      }) as typeof process.stdout.write,
+    );
 
     vi.stubGlobal("fetch", fetchMock);
     vi.resetModules();
@@ -66,13 +79,12 @@ describe("games route telegram logging", () => {
     expect(payload.gameId).toBeTruthy();
     expect(payload.hostPlayerId).toBeTruthy();
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(warnSpy).toHaveBeenCalledWith(
-      "[telegram.lobby-link]",
-      expect.objectContaining({
-        event: "created",
-        gameId: payload.gameId,
-        message: expect.stringContaining("Telegram API sendMessage failed with status 403"),
-      }),
+    expect(stdoutSpy).toHaveBeenCalled();
+    expect(logWrites.join("")).toContain('"context":"telegram.lobby-link"');
+    expect(logWrites.join("")).toContain('"event":"created"');
+    expect(logWrites.join("")).toContain(`"gameId":"${payload.gameId}"`);
+    expect(logWrites.join("")).toContain(
+      "\"message\":\"Telegram API sendMessage failed with status 403",
     );
   });
 });

--- a/src/lib/evidence-request.ts
+++ b/src/lib/evidence-request.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+import { UserFacingError } from "@/lib/errors";
+import {
+  EVIDENCE_KINDS,
+  isEvidenceKind,
+  MAX_EVIDENCE_DESCRIPTION_LENGTH,
+  MAX_EVIDENCE_REQUEST_SIZE_BYTES,
+  MAX_EVIDENCE_UPLOAD_SIZE_BYTES,
+  MAX_EVIDENCE_URL_LENGTH,
+} from "@/lib/types";
+
+const EVIDENCE_REQUEST_SIZE_LIMIT_MB = 10;
+const EVIDENCE_UPLOAD_SIZE_LIMIT_MB = 8;
+const SAFE_PROOF_URL_PATTERN = /^(\/|https?:\/\/)/;
+
+const evidenceRequestSchema = z.object({
+  playerId: z.string().trim().max(100).default(""),
+  description: z
+    .string()
+    .trim()
+    .min(1, "Add a short description for the proof.")
+    .max(
+      MAX_EVIDENCE_DESCRIPTION_LENGTH,
+      `Evidence descriptions must be ${MAX_EVIDENCE_DESCRIPTION_LENGTH} characters or fewer.`,
+    ),
+  kind: z.string().trim().refine(isEvidenceKind, {
+    message: `Evidence type must be one of: ${EVIDENCE_KINDS.join(", ")}.`,
+  }),
+  proofUrl: z
+    .string()
+    .trim()
+    .max(
+      MAX_EVIDENCE_URL_LENGTH,
+      `Proof URLs must be ${MAX_EVIDENCE_URL_LENGTH} characters or fewer.`,
+    )
+    .refine((value) => value === "" || SAFE_PROOF_URL_PATTERN.test(value), {
+      message: "Proof URLs must start with /, http://, or https://.",
+    }),
+});
+
+function getStringField(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value : "";
+}
+
+export function assertEvidenceRequestSize(request: Request) {
+  const contentLengthHeader = request.headers.get("content-length");
+
+  if (!contentLengthHeader) {
+    return;
+  }
+
+  const contentLength = Number.parseInt(contentLengthHeader, 10);
+
+  if (!Number.isFinite(contentLength) || contentLength <= 0) {
+    return;
+  }
+
+  if (contentLength > MAX_EVIDENCE_REQUEST_SIZE_BYTES) {
+    throw new UserFacingError(
+      `Evidence requests must be ${EVIDENCE_REQUEST_SIZE_LIMIT_MB} MB or smaller.`,
+    );
+  }
+}
+
+export function parseEvidenceRequest(formData: FormData) {
+  const parsed = evidenceRequestSchema.safeParse({
+    playerId: getStringField(formData, "playerId"),
+    description: getStringField(formData, "description"),
+    kind: getStringField(formData, "kind") || "photo",
+    proofUrl: getStringField(formData, "proofUrl"),
+  });
+
+  if (!parsed.success) {
+    throw new UserFacingError(parsed.error.issues[0]?.message ?? "Invalid evidence request.");
+  }
+
+  const rawFile = formData.get("file");
+
+  if (rawFile !== null && !(rawFile instanceof File)) {
+    throw new UserFacingError("Evidence uploads must be sent as files.");
+  }
+
+  const file = rawFile instanceof File && rawFile.size > 0 ? rawFile : null;
+
+  if (file && file.size > MAX_EVIDENCE_UPLOAD_SIZE_BYTES) {
+    throw new UserFacingError(
+      `Evidence uploads must be ${EVIDENCE_UPLOAD_SIZE_LIMIT_MB} MB or smaller.`,
+    );
+  }
+
+  if (
+    file?.type &&
+    parsed.data.kind === "photo" &&
+    !file.type.startsWith("image/")
+  ) {
+    throw new UserFacingError("Photo evidence must be uploaded as an image file.");
+  }
+
+  if (
+    file?.type &&
+    parsed.data.kind === "video" &&
+    !file.type.startsWith("video/")
+  ) {
+    throw new UserFacingError("Video evidence must be uploaded as a video file.");
+  }
+
+  if (!file && !parsed.data.proofUrl) {
+    throw new UserFacingError("Evidence needs either an upload or a proof URL.");
+  }
+
+  return {
+    ...parsed.data,
+    file,
+  };
+}

--- a/src/lib/server-log.ts
+++ b/src/lib/server-log.ts
@@ -1,4 +1,14 @@
+import pino from "pino";
+
 type LogMetadata = Record<string, unknown> | undefined;
+
+const logger = pino({
+  base: undefined,
+  level:
+    process.env.LOG_LEVEL ??
+    (process.env.NODE_ENV === "development" ? "debug" : "info"),
+  timestamp: pino.stdTimeFunctions.isoTime,
+});
 
 function getErrorDetails(error: unknown) {
   if (error instanceof Error) {
@@ -14,15 +24,28 @@ function getErrorDetails(error: unknown) {
   };
 }
 
+function logServerEvent(
+  level: "warn" | "error",
+  context: string,
+  error: unknown,
+  metadata?: LogMetadata,
+) {
+  logger[level](
+    {
+      context,
+      ...getErrorDetails(error),
+      ...(metadata ?? {}),
+    },
+    context,
+  );
+}
+
 export function logServerWarning(
   context: string,
   error: unknown,
   metadata?: LogMetadata,
 ) {
-  console.warn(`[${context}]`, {
-    ...getErrorDetails(error),
-    ...(metadata ?? {}),
-  });
+  logServerEvent("warn", context, error, metadata);
 }
 
 export function logServerError(
@@ -30,8 +53,5 @@ export function logServerError(
   error: unknown,
   metadata?: LogMetadata,
 ) {
-  console.error(`[${context}]`, {
-    ...getErrorDetails(error),
-    ...(metadata ?? {}),
-  });
+  logServerEvent("error", context, error, metadata);
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -22,6 +22,9 @@ export type EvidenceKind = "photo" | "video";
 
 export const EVIDENCE_KINDS = ["photo", "video"] as const;
 export const MAX_EVIDENCE_DESCRIPTION_LENGTH = 500;
+export const MAX_EVIDENCE_UPLOAD_SIZE_BYTES = 8 * 1024 * 1024;
+export const MAX_EVIDENCE_REQUEST_SIZE_BYTES = 10 * 1024 * 1024;
+export const MAX_EVIDENCE_URL_LENGTH = 2048;
 
 export function isEvidenceKind(value: string): value is EvidenceKind {
   return EVIDENCE_KINDS.includes(value as EvidenceKind);


### PR DESCRIPTION
## Summary
- add schema-backed validation for evidence submissions before they reach game logic
- enforce request and file upload size limits, plus safer proof URL and file-kind checks
- replace ad-hoc server `console.*` logging with structured `pino` logs and update tests accordingly

## Why
Issue #20 calls out loose evidence-route validation, missing upload guards, and console-based server logging. This PR addresses those items directly.

## Validation
- `npm run lint`
- `npx vitest run src/app/api/games/games-route.test.ts 'src/app/api/games/[gameId]/quests/[questId]/evidence/route.test.ts' src/lib/storage-config.test.ts`
- `git commit` hook (`npm run test:precommit`)

## Notes
- `.vercel/` was already ignored in this checkout, so no repository change was needed for that part of #20.
- The simulator build-time extraction/hardening item from #20 is not included in this PR yet.
- A broader `npm test` run still reports unrelated existing failures in other component and Telegram route tests; those were left out of this fix branch.

Refs #20
